### PR TITLE
swallow EPERM errors when trying to find the mount point for a path

### DIFF
--- a/lib/unix/sys/filesystem.rb
+++ b/lib/unix/sys/filesystem.rb
@@ -555,13 +555,16 @@ module Sys
       dev = File.stat(file).dev
       val = file
 
-      self.mounts.each{ |mnt|
-        mp = mnt.mount_point
-        if File.stat(mp).dev == dev
-          val = mp
-          break
+      self.mounts.each do |mnt|
+        begin
+          mp = mnt.mount_point
+          if File.stat(mp).dev == dev
+            val = mp
+            break
+          end
+        rescue Errno::EPERM
         end
-      }
+      end
 
       val
     end


### PR DESCRIPTION
Since this method will just return the original path on failure, swallowing this error seems safe enough. I've seen problems with this when there are FUSE mounts present, since FUSE mounts are usually locked to 0700 permissions.
