### PR TITLE
check for gvfs before doing a stat

### DIFF
--- a/lib/unix/sys/filesystem.rb
+++ b/lib/unix/sys/filesystem.rb
@@ -557,7 +557,7 @@ module Sys
 
       self.mounts.each{ |mnt|
         mp = mnt.mount_point
-        if File.stat(mp).dev == dev
+        if !mp[/gvfs/] && File.stat(mp).dev == dev
           val = mp
           break
         end

--- a/lib/unix/sys/filesystem.rb
+++ b/lib/unix/sys/filesystem.rb
@@ -557,9 +557,13 @@ module Sys
 
       self.mounts.each{ |mnt|
         mp = mnt.mount_point
-        if !mp[/gvfs/] && File.stat(mp).dev == dev
-          val = mp
-          break
+        begin
+          if File.stat(mp).dev == dev
+            val = mp
+            break
+          end
+        rescue Errno::EACCES
+          next
         end
       }
 


### PR DESCRIPTION
I've had problems using sys-filesystem's Filesystem.mount_point(<dir>) when the directory is under a USB mounted file system when we are using gnome gvfs auto loader and there are multiple users on the system. It seems as if the users will grab hold of the directory and not even the root user can do a File.stat on that directory. 

So I've put a check in for any gvfs to ignore it.