### PR TITLE
Fix for FreeBSD 10 block_size

### DIFF
--- a/lib/unix/sys/filesystem.rb
+++ b/lib/unix/sys/filesystem.rb
@@ -220,6 +220,11 @@ module Sys
         obj.block_size /= 256
       end
 
+      # FreeBSD 10 does things a little differently too
+      if RbConfig::CONFIG['host_os'] =~ /freebsd10/i
+        obj.block_size = obj.fragment_size
+      end
+
       if fs.members.include?(:f_basetype)
         obj.base_type = fs[:f_basetype].to_s
       end


### PR DESCRIPTION
Per: https://github.com/djberg96/sys-filesystem/issues/14.

I specifically targeted FreeBSD10 only in this change as I do not have access to older versions and don't want to chance breaking them.
