### PR TITLE
use /proc/mounts as a fallback

### DIFF
--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -42,6 +42,8 @@ module Sys
       MOUNT_FILE = '/etc/mtab'
     elsif File.exist?('/etc/mnttab')
       MOUNT_FILE = '/etc/mnttab'
+    elsif File.exist?('/proc/mounts')
+      MOUNT_FILE = '/proc/mounts'
     else
       MOUNT_FILE = 'getmntinfo'
     end


### PR DESCRIPTION
In chroots only /proc/mounts is present. Fixes: #22