### PR TITLE
Pathname does not have wincode method

### DIFF
--- a/lib/sys/windows/sys/filesystem/helper.rb
+++ b/lib/sys/windows/sys/filesystem/helper.rb
@@ -5,3 +5,11 @@ class String
     (self.tr(File::SEPARATOR, File::ALT_SEPARATOR) + 0.chr).encode('UTF-16LE')
   end
 end
+
+class Pathname
+  # Convenience method for converting strings to UTF-16LE for wide character
+  # functions that require it.
+  def wincode
+    self.to_s.wincode
+  end
+end


### PR DESCRIPTION
[2017-08-09 11:53:50 #6448] ERROR: undefined method `wincode' for #<Pathname:P:/example/path> (NoMethodError)
P:/███/Ruby193p551x86/lib/ruby/gems/1.9.1/gems/sys-filesystem-1.1.7/lib/sys/windows/sys/filesystem.rb:244:in `mount_point'
P:/███/Ruby193p551x86/lib/ruby/gems/1.9.1/gems/sys-filesystem-1.1.7/lib/sys/windows/sys/filesystem.rb:267:in `stat'

Got this error from 

Sys::Filesystem.stat("P:\\example\\path")