### PR TITLE
Fix UNC Path test

### DIFF
--- a/lib/sys/windows/sys/filesystem.rb
+++ b/lib/sys/windows/sys/filesystem.rb
@@ -244,7 +244,7 @@ module Sys
       wfile = FFI::MemoryPointer.from_string(file.to_s.wincode)
 
       if PathStripToRootW(wfile)
-        wfile.read_string(wfile.size).split("\000\000").first.tr(0.chr, '')
+        wfile.read_string(wfile.size).split("\000\000").first.tr(0.chr, '').gsub(/(?!\\\\)$/, "\\")
       else
         nil
       end


### PR DESCRIPTION
Fixes call: Sys::Filesystem.stat("\\\\127.0.0.1\\C$\\")

Was erroring with
SystemCallError: The filename, directory name, or volume label syntax is incorrect. - GetVolumInformation
gems/sys-filesystem-1.1.7.1/lib/sys/windows/sys/filesystem.rb:318:in `stat'

GetVolumeInformationW requires a trailing slash. It seems this was being stripped off in my test case.