### PR TITLE
Fixed calculation of bytes_free on Unix.

### DIFF
--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -133,7 +133,7 @@ module Sys
 
       # Returns the total amount of free space on the partition.
       def bytes_free
-        blocks_available * fragment_size
+        blocks_free * fragment_size
       end
 
       # Returns the total amount of used space on the partition.

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -132,6 +132,7 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
   def test_stat_bytes_free
     assert_respond_to(@stat, :bytes_free)
     assert_kind_of(Numeric, @stat.bytes_free)
+    assert_equal(@stat.bytes_free, @stat.blocks_free * @stat.fragment_size)
   end
 
   def test_stat_bytes_used


### PR DESCRIPTION
Currently `bytes_free` on Unix is calculated based on `blocks_available`, not on `blocks_free`. It looks inconsistent. I think, `bytes_free` should be calculated based on `blocks_free`. If someone wants to know available bytes - maybe a new method `bytes_available` should be introduced.

On Windows free space calculation is done differently, but consistently: `blocks_free` is calculated based on `block_size`.
