### PR TITLE
Stat.bytes_available method

### DIFF
--- a/examples/example_stat.rb
+++ b/examples/example_stat.rb
@@ -15,6 +15,8 @@ puts "Block size: " + stat.block_size.to_s
 puts "Fragment size: " + stat.fragment_size.to_s
 puts "Blocks free: " + stat.blocks_free.to_s
 puts "Blocks available: " + stat.blocks_available.to_s
+puts "Bytes free: " + stat.bytes_free.to_s
+puts "Bytes available: " + stat.bytes_available.to_s
 puts "Files/Inodes: " + stat.files.to_s
 puts "Files/Inodes free: " + stat.files_free.to_s
 puts "Files/Inodes available: " + stat.files_available.to_s

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -136,6 +136,11 @@ module Sys
         blocks_free * fragment_size
       end
 
+      # Returns the amount of free space available to unprivileged processes.
+      def bytes_available
+        blocks_available * fragment_size
+      end
+
       # Returns the total amount of used space on the partition.
       def bytes_used
         bytes_total - bytes_free

--- a/lib/sys/windows/sys/filesystem.rb
+++ b/lib/sys/windows/sys/filesystem.rb
@@ -93,7 +93,7 @@ module Sys
       # The file system type, e.g. NTFS, FAT, etc.
       attr_reader :base_type
 
-      # Returns the total amount of free space on the partition.
+      # The total amount of free space on the partition.
       attr_reader :bytes_free
 
       alias inodes files

--- a/lib/sys/windows/sys/filesystem.rb
+++ b/lib/sys/windows/sys/filesystem.rb
@@ -96,6 +96,9 @@ module Sys
       # The total amount of free space on the partition.
       attr_reader :bytes_free
 
+      # The amount of free space available to unprivileged processes.
+      attr_reader :bytes_available
+
       alias inodes files
       alias inodes_free files_free
       alias inodes_available files_available
@@ -343,6 +346,7 @@ module Sys
       stat_obj.instance_variable_set(:@flags, flags)
       stat_obj.instance_variable_set(:@filesystem_id, vol_serial)
       stat_obj.instance_variable_set(:@bytes_free, bytes_free)
+      stat_obj.instance_variable_set(:@bytes_available, bytes_avail)
 
       stat_obj.freeze # Read-only object
     end

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -135,6 +135,12 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
     assert_equal(@stat.bytes_free, @stat.blocks_free * @stat.fragment_size)
   end
 
+  def test_stat_bytes_available
+    assert_respond_to(@stat, :bytes_available)
+    assert_kind_of(Numeric, @stat.bytes_available)
+    assert_equal(@stat.bytes_available, @stat.blocks_available * @stat.fragment_size)
+  end
+
   def test_stat_bytes_used
     assert_respond_to(@stat, :bytes_used)
     assert_kind_of(Numeric, @stat.bytes_used)

--- a/test/test_sys_filesystem_windows.rb
+++ b/test/test_sys_filesystem_windows.rb
@@ -116,6 +116,12 @@ class TC_Sys_Filesystem_Windows < Test::Unit::TestCase
     assert_equal(@stat.bytes_free, @stat.blocks_free * @stat.block_size)
   end
 
+  test "stat bytes_available basic functionality" do
+    assert_respond_to(@stat, :bytes_available)
+    assert_kind_of(Numeric, @stat.bytes_available)
+    assert_equal(@stat.bytes_available, @stat.blocks_available * @stat.block_size)
+  end
+
   test "stat bytes_used basic functionality" do
     assert_respond_to(@stat, :bytes_used)
     assert_kind_of(Numeric, @stat.bytes_used)

--- a/test/test_sys_filesystem_windows.rb
+++ b/test/test_sys_filesystem_windows.rb
@@ -113,6 +113,7 @@ class TC_Sys_Filesystem_Windows < Test::Unit::TestCase
   test "stat bytes_free basic functionality" do
     assert_respond_to(@stat, :bytes_free)
     assert_kind_of(Numeric, @stat.bytes_free)
+    assert_equal(@stat.bytes_free, @stat.blocks_free * @stat.block_size)
   end
 
   test "stat bytes_used basic functionality" do


### PR DESCRIPTION
This pull request adds Stat.bytes_available method and a couple of other small improvements.

Note that I could not test the Windows changes, because I don't have a setup for it. I added Windows-specific code for `bytes_available` similarly to how the code for `bytes_free` is written.
