### PR TITLE
Add a mount singleton method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-== 1.3.0 - ???
+== 1.3.0 - 3-Oct-2019
 * Added the mount and umount singleton methods.
 * Changed an internal class variable to a frozen constant.
 

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -1,7 +1,7 @@
 module Sys
   class Filesystem
     # The version of the sys-filesystem library
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.3.0'.freeze
   end
 end
 

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -393,5 +393,25 @@ module Sys
         raise Error, 'mount() function failed: ' + strerror(FFI.errno)
       end
     end
+
+    # Removes the attachment of the (topmost) filesystem mounted on target.
+    # Additional flags may be provided for operating systems that support
+    # the umount2 function. Otherwise this argument is ignored.
+    #
+    # Typically requires admin privileges.
+    #
+    def self.umount(target, flags = 0)
+      if respond_to?(:umount2)
+        function = 'umount2'
+        rv = umount2(target, flags)
+      else
+        function = 'umount'
+        rv = umount(target)
+      end
+
+      if rv != 0
+        raise Error, "#{function} function failed: " + strerror(FFI.errno)
+      end
+    end
   end
 end

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -379,5 +379,19 @@ module Sys
 
       val
     end
+
+    # Attach the filesystem specified by +source+ to the location (a directory
+    # or file) specified by the pathname in +target+.
+    #
+    # Note that the +source+ is often a pathname referring to a device, but
+    # can also be the pathname of a directory or file, or a dummy string.
+    #
+    # Typically requires admin privileges.
+    #
+    def self.mount(source, target, fstype = nil, flags = 0, data = nil)
+      if mount_c(source, target, fstype, flags, data) != 0
+        raise Error, 'mount() function failed: ' + strerror(FFI.errno)
+      end
+    end
   end
 end

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -386,9 +386,12 @@ module Sys
     # Note that the +source+ is often a pathname referring to a device, but
     # can also be the pathname of a directory or file, or a dummy string.
     #
+    # By default this method will assume 'ext2' as the filesystem type, but
+    # you should update this as needed.
+    #
     # Typically requires admin privileges.
     #
-    def self.mount(source, target, fstype = nil, flags = 0, data = nil)
+    def self.mount(source, target, fstype = 'ext2', flags = 0, data = nil)
       if mount_c(source, target, fstype, flags, data) != 0
         raise Error, 'mount() function failed: ' + strerror(FFI.errno)
       end

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -14,7 +14,7 @@ module Sys
     private
 
     # Readable versions of constant names
-    @@opt_names = {
+    OPT_NAMES = {
       MNT_RDONLY           => 'read-only',
       MNT_SYNCHRONOUS      => 'synchronous',
       MNT_NOEXEC           => 'noexec',
@@ -35,7 +35,7 @@ module Sys
       MNT_NOUSERXATTR      => 'nouserxattr',
       MNT_DEFWRITE         => 'defwrite',
       MNT_NOATIME          => 'noatime'
-    }
+    }.freeze
 
     # File used to read mount informtion from.
     if File.exist?('/etc/mtab')
@@ -268,7 +268,7 @@ module Sys
           string = ""
           flags = mnt[:f_flags] & MNT_VISFLAGMASK
 
-          @@opt_names.each{ |key,val|
+          OPT_NAMES.each{ |key,val|
             if flags & key > 0
               if string.empty?
                 string << val

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -392,6 +392,8 @@ module Sys
       if mount_c(source, target, fstype, flags, data) != 0
         raise Error, 'mount() function failed: ' + strerror(FFI.errno)
       end
+
+      self
     end
 
     # Removes the attachment of the (topmost) filesystem mounted on target.
@@ -400,8 +402,8 @@ module Sys
     #
     # Typically requires admin privileges.
     #
-    def self.umount(target, flags = 0)
-      if respond_to?(:umount2)
+    def self.umount(target, flags = nil)
+      if flags && respond_to?(:umount2)
         function = 'umount2'
         rv = umount2(target, flags)
       else
@@ -412,6 +414,8 @@ module Sys
       if rv != 0
         raise Error, "#{function} function failed: " + strerror(FFI.errno)
       end
+
+      self
     end
   end
 end

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -391,6 +391,10 @@ module Sys
     #
     # Typically requires admin privileges.
     #
+    # Example:
+    #
+    #   Sys::Filesystem.mount('/dev/loop0', '/home/you/tmp', 'ext4', Sys::Filesystem::MNT_RDONLY)
+    #
     def self.mount(source, target, fstype = 'ext2', flags = 0, data = nil)
       if mount_c(source, target, fstype, flags, data) != 0
         raise Error, 'mount() function failed: ' + strerror(FFI.errno)

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -405,10 +405,10 @@ module Sys
     def self.umount(target, flags = nil)
       if flags && respond_to?(:umount2)
         function = 'umount2'
-        rv = umount2(target, flags)
+        rv = umount2_c(target, flags)
       else
         function = 'umount'
-        rv = umount(target)
+        rv = umount_c(target)
       end
 
       if rv != 0

--- a/lib/sys/unix/sys/filesystem/constants.rb
+++ b/lib/sys/unix/sys/filesystem/constants.rb
@@ -36,6 +36,32 @@ module Sys
         MNT_NOUSERXATTR | MNT_DEFWRITE  | MNT_MULTILABEL |
         MNT_NOATIME | MNT_CPROTECT
       )
+
+      MS_RDONLY = 1
+      MS_NOSUID = 2
+      MS_NODEV = 4
+      MS_NOEXEC = 8
+      MS_SYNCHRONOUS = 16
+      MS_REMOUNT = 32
+      MS_MANDLOCK = 64
+      MS_DIRSYNC = 128
+      MS_NOATIME = 1024
+      MS_NODIRATIME = 2048
+      MS_BIND = 4096
+      MS_MOVE = 8192
+      MS_REC = 16384
+      MS_SILENT = 32768
+      MS_POSIXACL = 1 << 16
+      MS_UNBINDABLE = 1 << 17
+      MS_PRIVATE = 1 << 18
+      MS_SLAVE = 1 << 19
+      MS_SHARED = 1 << 20
+      MS_RELATIME = 1 << 21
+      MS_KERNMOUNT = 1 << 22
+      MS_I_VERSION =  1 << 23
+      MS_STRICTATIME = 1 << 24
+      MS_ACTIVE = 1 << 30
+      MS_NOUSER = 1 << 31
     end
   end
 end

--- a/lib/sys/unix/sys/filesystem/constants.rb
+++ b/lib/sys/unix/sys/filesystem/constants.rb
@@ -62,6 +62,11 @@ module Sys
       MS_STRICTATIME = 1 << 24
       MS_ACTIVE = 1 << 30
       MS_NOUSER = 1 << 31
+
+      MNT_FORCE = 1
+      MNT_DETACH = 2
+      MNT_EXPIRE = 4
+      UMOUNT_NOFOLLOW = 8
     end
   end
 end

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -14,7 +14,7 @@ module Sys
       end
 
       attach_function(:strerror, [:int], :string)
-      attach_function(:mount_c, :mount, [:string, :string, :string, :ulong, :void], :int)
+      attach_function(:mount_c, :mount, [:string, :string, :string, :ulong, :string], :int)
       attach_function(:umount_c, :umount, [:string], :int)
 
       private_class_method :statvfs, :strerror, :mount_c, :umount_c

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -14,8 +14,10 @@ module Sys
       end
 
       attach_function(:strerror, [:int], :string)
+      attach_function(:mount, [:string, :string, :string, :ulong, :void], :int)
+      attach_function(:umount, [:string], :int)
 
-      private_class_method :statvfs, :strerror
+      private_class_method :statvfs, :strerror, :mount, :umount
 
       begin
         if RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
@@ -27,7 +29,8 @@ module Sys
           attach_function(:getmntent, [:pointer], :pointer)
           attach_function(:setmntent, [:string, :string], :pointer)
           attach_function(:endmntent, [:pointer], :int)
-          private_class_method :getmntent, :setmntent, :endmntent
+          attach_function(:umount2, [:string, :int], :int)
+          private_class_method :getmntent, :setmntent, :endmntent, :umount2
         end
       rescue FFI::NotFoundError
         if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -14,10 +14,10 @@ module Sys
       end
 
       attach_function(:strerror, [:int], :string)
-      attach_function(:mount, [:string, :string, :string, :ulong, :void], :int)
-      attach_function(:umount, [:string], :int)
+      attach_function(:mount_c, :mount, [:string, :string, :string, :ulong, :void], :int)
+      attach_function(:umount_c, :umount, [:string], :int)
 
-      private_class_method :statvfs, :strerror, :mount, :umount
+      private_class_method :statvfs, :strerror, :mount_c, :umount_c
 
       begin
         if RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i

--- a/lib/sys/windows/sys/filesystem.rb
+++ b/lib/sys/windows/sys/filesystem.rb
@@ -353,6 +353,29 @@ module Sys
       stat_obj.freeze # Read-only object
     end
 
+    # Associate a volume with a drive letter or a directory on another volume.
+    #
+    def self.mount(mount_point, volume_name)
+      mount_pointw = mount_point.to_s.wincode
+      volume_namew = volume_name.to_s.wincode
+
+      unless SetVolumeMountPointW(mount_pointw, volume_namew)
+        raise SystemCallError.new('SetVolumeMountPoint', FFI.errno)
+      end
+
+      self
+    end
+
+    # Deletes a drive letter or mounted folder.
+    #
+    def self.umount(mount_point)
+      unless DeleteVolumeMountPoint(mount_point)
+        raise SystemCallError.new('DeleteVolumeMountPoint', FFI.errno)
+      end
+
+      self
+    end
+
     private
 
     # This method is used to get the boot time of the system, which is used

--- a/lib/sys/windows/sys/filesystem.rb
+++ b/lib/sys/windows/sys/filesystem.rb
@@ -355,11 +355,17 @@ module Sys
 
     # Associate a volume with a drive letter or a directory on another volume.
     #
-    def self.mount(mount_point, volume_name)
-      mount_pointw = mount_point.to_s.wincode
-      volume_namew = volume_name.to_s.wincode
+    def self.mount(target, source)
+      targetw = target.to_s.wincode
+      sourcew = source.to_s.wincode
 
-      unless SetVolumeMountPointW(mount_pointw, volume_namew)
+      volume_namew = (0.chr * 256).wincode
+
+      unless GetVolumeNameForVolumeMountPointW(sourcew, volume_namew, volume_namew.size)
+        raise SystemCallError.new('GetVolumeNameForVolumeMountPoint', FFI.errno)
+      end
+
+      unless SetVolumeMountPointW(targetw, volume_namew)
         raise SystemCallError.new('SetVolumeMountPoint', FFI.errno)
       end
 

--- a/lib/sys/windows/sys/filesystem/functions.rb
+++ b/lib/sys/windows/sys/filesystem/functions.rb
@@ -14,6 +14,7 @@ module Sys
         end
       end
 
+      attach_pfunc :DeleteVolumeMountPointA, [:string], :bool
       attach_pfunc :GetDiskFreeSpaceW, [:buffer_in, :pointer, :pointer, :pointer, :pointer], :bool
       attach_pfunc :GetDiskFreeSpaceExW, [:buffer_in, :pointer, :pointer, :pointer], :bool
       attach_pfunc :GetLogicalDriveStringsA, [:ulong, :pointer], :ulong
@@ -27,6 +28,7 @@ module Sys
         :bool
 
       attach_pfunc :QueryDosDeviceA, [:buffer_in, :buffer_out, :ulong], :ulong
+      attach_pfunc :SetVolumeMountPointW, [:buffer_in, :buffer_in], :bool
 
       ffi_lib :shlwapi
 

--- a/lib/sys/windows/sys/filesystem/functions.rb
+++ b/lib/sys/windows/sys/filesystem/functions.rb
@@ -27,6 +27,7 @@ module Sys
         [:buffer_in, :pointer, :ulong, :pointer, :pointer, :pointer, :pointer, :ulong],
         :bool
 
+      attach_pfunc :GetVolumeNameForVolumeMountPointW, [:buffer_in, :buffer_in, :ulong], :bool
       attach_pfunc :QueryDosDeviceA, [:buffer_in, :buffer_out, :ulong], :ulong
       attach_pfunc :SetVolumeMountPointW, [:buffer_in, :buffer_in], :bool
 

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-filesystem'
-  spec.version    = '1.2.0'
+  spec.version    = '1.3.0'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -25,7 +25,8 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
   end
 
   def test_version
-    assert_equal('1.2.0', Filesystem::VERSION)
+    assert_equal('1.3.0', Filesystem::VERSION)
+    assert_true(Filesystem::VERSION.frozen?)
   end
 
   def test_stat_path

--- a/test/test_sys_filesystem_windows.rb
+++ b/test/test_sys_filesystem_windows.rb
@@ -276,6 +276,16 @@ class TC_Sys_Filesystem_Windows < Test::Unit::TestCase
     assert_equal(0, @size.to_gb)
   end
 
+  # Mount and Unmount
+
+  test "mount singleton method exists" do
+    assert_respond_to(Sys::Filesystem, :mount)
+  end
+
+  test "umount singleton method exists" do
+    assert_respond_to(Sys::Filesystem, :umount)
+  end
+
   # FFI
 
   test "internal ffi functions are not public" do

--- a/test/test_sys_filesystem_windows.rb
+++ b/test/test_sys_filesystem_windows.rb
@@ -20,7 +20,8 @@ class TC_Sys_Filesystem_Windows < Test::Unit::TestCase
   end
 
   test "version number is set to the expected value" do
-    assert_equal('1.2.0', Filesystem::VERSION)
+    assert_equal('1.3.0', Filesystem::VERSION)
+    assert_true(Filesystem::VERSION.frozen?)
   end
 
   test "stat path works as expected" do


### PR DESCRIPTION
This adds the `mount` and `umount` singleton methods to the base `Sys::Filesystem` class. On Unix systems, this is a thin wrapper around the `mount` and `umount` functions (or `unmount` on Macs).

While Windows isn't a precise analogue, I've made it as close as I can, wrapping the `SetVolumeMountPoint` method. Internally I use the `GetVolumeNameForVolumeMountPoint` so that users don't have to calculate the underlying volume name manually.

Otherwise, the only change was to switch `@@opt_names` to `OPT_NAMES`.