### PR TITLE
Fix Statvfs struct size, test cleanup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+== 1.3.1 - 15-Oct-2019
+* Fixed a bug where the Statvfs and Statfs structs were not allocated properly
+  on Linux, which could cause issues. Thanks go to Daniele Orlandi for the spot.
+* Added specs to ensure that the FFI struct size matches the C struct size.
+  This required adding mkmf-lite as a development dependency.
+* Added a slightly more pessimistic version requirement for test-unit.
+
 == 1.3.0 - 3-Oct-2019
 * Added the mount and umount singleton methods.
 * Changed an internal class variable to a frozen constant.

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -1,7 +1,7 @@
 module Sys
   class Filesystem
     # The version of the sys-filesystem library
-    VERSION = '1.3.0'.freeze
+    VERSION = '1.3.1'.freeze
   end
 end
 

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -19,7 +19,7 @@ module Sys
       begin
         attach_function(:umount_c, :umount, [:string], :int)
       rescue FFI::NotFoundError
-        if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i
+        if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd/i
           attach_function(:umount_c, :unmount, [:string], :int)
         end
       end

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -112,18 +112,16 @@ module Sys
           layout(
             :f_bsize, :ulong,
             :f_frsize, :ulong,
-            :f_blocks, :ulong,
-            :f_bfree, :ulong,
-            :f_bavail, :ulong,
-            :f_files, :ulong,
-            :f_ffree, :ulong,
-            :f_favail, :ulong,
+            :f_blocks, :uint64,
+            :f_bfree, :uint64,
+            :f_bavail, :uint64,
+            :f_files, :uint64,
+            :f_ffree, :uint64,
+            :f_favail, :uint64,
             :f_fsid, :ulong,
             :f_flag, :ulong,
             :f_namemax, :ulong,
-            :f_ftype, :ulong,
-            :f_basetype, [:char, 16],
-            :f_str, [:char, 16]
+            :f_spare, [:int, 6]
           )
         end
       end

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -39,6 +39,21 @@ module Sys
             :f_mntfromname, [:char, MNAMELEN],
             :f_mntonname, [:char, MNAMELEN]
           )
+        elsif RbConfig::CONFIG['host_os'] =~ /linux/i
+          layout(
+            :f_type, :ulong,
+            :f_bsize, :ulong,
+            :f_blocks, :uint64,
+            :f_bfree, :uint64,
+            :f_bavail, :uint64,
+            :f_files, :uint64,
+            :f_ffree, :uint64,
+            :f_fsid, [:int, 2],
+            :f_namelen, :ulong,
+            :f_frsize, :ulong,
+            :f_flags, :ulong,
+            :f_spare, [:ulong, 4]
+          )
         else
           layout(
             :f_bsize, :uint32,

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'
   spec.summary    = 'A Ruby interface for getting file system information.'
-  spec.test_files = Dir['test/*.rb']
   spec.license    = 'Apache-2.0'
+  spec.test_files = Dir['test/*.rb']
   spec.files      = Dir['**/*'].reject{ |f| f.include?('git') }
   spec.cert_chain = Dir['certs/*']
    

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-filesystem'
-  spec.version    = '1.3.0'
+  spec.version    = '1.3.1'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files  = ['CHANGES', 'README', 'MANIFEST']
 
   spec.add_dependency('ffi')
-  spec.add_development_dependency('test-unit', '>= 2.5.0')
   spec.add_development_dependency('rake')
+  spec.add_development_dependency('test-unit', '~> 3.3')
+  spec.add_development_dependency('mkmf-lite', '~> 0.3')
 
   spec.metadata = {
     'homepage_uri'      => 'https://github.com/djberg96/sys-filesystem',

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -26,92 +26,92 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
     @array = []
   end
 
-  def test_version
+  test "version number is set to the expected value" do
     assert_equal('1.3.1', Filesystem::VERSION)
     assert_true(Filesystem::VERSION.frozen?)
   end
 
-  def test_stat_path
+  test "stat path works as expected" do
     assert_respond_to(@stat, :path)
     assert_equal("/", @stat.path)
   end
 
-  def test_stat_block_size
+  test "stat block_size works as expected" do
     assert_respond_to(@stat, :block_size)
     assert_kind_of(Numeric, @stat.block_size)
   end
 
-  def test_block_size_is_a_plausible_value
+  test "stat block_size is a plausible value" do
     assert_true(@stat.block_size >= 1024)
     assert_true(@stat.block_size <= 16384)
   end
 
-  def test_stat_fragment_size
+  test "stat fragment_size works as expected" do
     assert_respond_to(@stat, :fragment_size)
     assert_kind_of(Numeric, @stat.fragment_size)
   end
 
-  def test_stat_blocks
+  test "stat blocks works as expected" do
     assert_respond_to(@stat, :blocks)
     assert_kind_of(Numeric, @stat.blocks)
   end
 
-  def test_stat_blocks_free
+  test "stat blocks_free works as expected" do
     assert_respond_to(@stat, :blocks_free)
     assert_kind_of(Numeric, @stat.blocks_free)
   end
 
-  def test_stat_blocks_available
+  test "stat blocks_available works as expected" do
     assert_respond_to(@stat, :blocks_available)
     assert_kind_of(Numeric, @stat.blocks_available)
   end
 
-  def test_stat_files
+  test "stat files works as expected" do
     assert_respond_to(@stat, :files)
     assert_kind_of(Numeric, @stat.files)
   end
 
-  def test_inodes_alias
+  test "stat inodes is an alias for files" do
     assert_respond_to(@stat, :inodes)
     assert_true(@stat.method(:inodes) == @stat.method(:files))
   end
 
-  def test_stat_files_free
+  test "stat files tree works as expected" do
     assert_respond_to(@stat, :files_free)
     assert_kind_of(Numeric, @stat.files_free)
   end
 
-  def test_stat_inodes_free_alias
+  test "stat inodes_free is an alias for files_free" do
     assert_respond_to(@stat, :inodes_free)
     assert_true(@stat.method(:inodes_free) == @stat.method(:files_free))
   end
 
-  def test_stat_files_available
+  test "stat files_available works as expected" do
     assert_respond_to(@stat, :files_available)
     assert_kind_of(Numeric, @stat.files_available)
   end
 
-  def test_stat_inodes_available_alias
+  test "stat inodes_available is an alias for files_available" do
     assert_respond_to(@stat, :inodes_available)
     assert_true(@stat.method(:inodes_available) == @stat.method(:files_available))
   end
 
-  def test_stat_filesystem_id
+  test "stat filesystem_id works as expected" do
     assert_respond_to(@stat, :filesystem_id)
     assert_kind_of(Integer, @stat.filesystem_id)
   end
 
-  def test_stat_flags
+  test "stat flags works as expected" do
     assert_respond_to(@stat, :flags)
     assert_kind_of(Numeric, @stat.flags)
   end
 
-  def test_stat_name_max
+  test "stat name_max works as expected" do
     assert_respond_to(@stat, :name_max)
     assert_kind_of(Numeric, @stat.name_max)
   end
 
-  def test_stat_base_type
+  test "stat base_type works as expected" do
     omit_unless(@@solaris, "base_type test skipped except on Solaris")
 
     assert_respond_to(@stat, :base_type)

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -118,7 +118,7 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
     assert_kind_of(String, @stat.base_type)
   end
 
-  def test_stat_constants
+  test "stat constants are defined" do
     assert_not_nil(Filesystem::Stat::RDONLY)
     assert_not_nil(Filesystem::Stat::NOSUID)
 
@@ -127,65 +127,65 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
     assert_not_nil(Filesystem::Stat::NOTRUNC)
   end
 
-  def test_stat_bytes_total
+  test "stat bytes_total works as expected" do
     assert_respond_to(@stat, :bytes_total)
     assert_kind_of(Numeric, @stat.bytes_total)
   end
 
-  def test_stat_bytes_free
+  test "stat bytes_free works as expected" do
     assert_respond_to(@stat, :bytes_free)
     assert_kind_of(Numeric, @stat.bytes_free)
     assert_equal(@stat.bytes_free, @stat.blocks_free * @stat.fragment_size)
   end
 
-  def test_stat_bytes_available
+  test "stat bytes_available works as expected" do
     assert_respond_to(@stat, :bytes_available)
     assert_kind_of(Numeric, @stat.bytes_available)
     assert_equal(@stat.bytes_available, @stat.blocks_available * @stat.fragment_size)
   end
 
-  def test_stat_bytes_used
+  test "stat bytes works as expected" do
     assert_respond_to(@stat, :bytes_used)
     assert_kind_of(Numeric, @stat.bytes_used)
   end
 
-  def test_stat_percent_used
+  test "stat percent_used works as expected" do
     assert_respond_to(@stat, :percent_used)
     assert_kind_of(Float, @stat.percent_used)
   end
 
-  def test_stat_expected_errors
+  test "stat singleton method requires an argument" do
     assert_raises(ArgumentError){ Filesystem.stat }
   end
 
-  def test_stat_case_insensitive
+  test "stat case_insensitive method works as expected" do
     expected = @@darwin ? true : false
     assert_equal(expected, @stat.case_insensitive?)
     assert_equal(expected, Filesystem.stat(Dir.home).case_insensitive?)
   end
 
-  def test_stat_case_sensitive
+  test "stat case_sensitive method works as expected" do
     expected = @@darwin ? false : true
     assert_equal(expected, @stat.case_sensitive?)
     assert_equal(expected, Filesystem.stat(Dir.home).case_sensitive?)
   end
 
-  def test_numeric_methods_basic
+  test "numeric helper methods are defined" do
     assert_respond_to(@size, :to_kb)
     assert_respond_to(@size, :to_mb)
     assert_respond_to(@size, :to_gb)
     assert_respond_to(@size, :to_tb)
   end
 
-  def test_to_kb
+  test "to_kb works as expected" do
     assert_equal(57344, @size.to_kb)
   end
 
-  def test_to_mb
+  test "to_mb works as expected" do
     assert_equal(56, @size.to_mb)
   end
 
-  def test_to_gb
+  test "to_gb works as expected" do
     assert_equal(0, @size.to_gb)
   end
 

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -5,8 +5,10 @@
 # This test suite should be run via the 'rake test' task.
 ####################################################################
 require 'test-unit'
-require 'sys/filesystem'
+require 'sys-filesystem'
+require 'mkmf-lite'
 include Sys
+include Mkmf::Lite
 
 class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
   def self.startup
@@ -289,6 +291,11 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
 
   def test_umount_singleton_method
     assert_respond_to(Sys::Filesystem, :umount)
+  end
+
+  test "structs are expected size" do
+    assert_equal(check_sizeof('struct statvfs', 'sys/statvfs.h'), Filesystem::Structs::Statvfs.size)
+    assert_equal(check_sizeof('struct statfs', 'sys/statfs.h'), Filesystem::Structs::Statfs.size)
   end
 
   def teardown

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -191,56 +191,56 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
 
   # Filesystem::Mount tests
 
-  def test_mounts_with_no_block
+  test "mounts singleton method works as expected without a block" do
     assert_nothing_raised{ @array = Filesystem.mounts }
     assert_kind_of(Filesystem::Mount, @array[0])
   end
 
-  def test_mounts_with_block
+  test "mounts singleton method works as expected with a block" do
     assert_nothing_raised{ Filesystem.mounts{ |m| @array << m } }
     assert_kind_of(Filesystem::Mount, @array[0])
   end
 
-  def test_mounts_high_iteration
+  test "calling the mounts singleton method a large number of times does not cause issues" do
     assert_nothing_raised{ 1000.times{ @array = Filesystem.mounts } }
   end
 
-  def test_mount_name
+  test "mount name method works as expected" do
     assert_respond_to(@mnt, :name)
     assert_kind_of(String, @mnt.name)
   end
 
-  def test_fsname_alias
+  test "mount fsname is an alias for name" do
     assert_respond_to(@mnt, :fsname)
     assert_true(@mnt.method(:fsname) == @mnt.method(:name))
   end
 
-  def test_mount_point
+  test "mount point method works as expected" do
     assert_respond_to(@mnt, :mount_point)
     assert_kind_of(String, @mnt.mount_point)
   end
 
-  def test_dir_alias
+  test "mount dir is an alias for mount_point" do
     assert_respond_to(@mnt, :dir)
     assert_true(@mnt.method(:dir) == @mnt.method(:mount_point))
   end
 
-  def test_mount_type
+  test "mount mount_type works as expected" do
     assert_respond_to(@mnt, :mount_type)
     assert_kind_of(String, @mnt.mount_type)
   end
 
-  def test_mount_options
+  test "mount options works as expected" do
     assert_respond_to(@mnt, :options)
     assert_kind_of(String, @mnt.options)
   end
 
-  def test_opts_alias
+  test "mount opts is an alias for options" do
     assert_respond_to(@mnt, :opts)
     assert_true(@mnt.method(:opts) == @mnt.method(:options))
   end
 
-  def test_mount_time
+  test "mount time works as expected" do
     assert_respond_to(@mnt, :mount_time)
 
     if @@solaris
@@ -250,47 +250,49 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
     end
   end
 
-  def test_mount_dump_frequency
+  test "mount dump_frequency works as expected" do
     msg = 'dump_frequency test skipped on this platform'
     omit_if(@@solaris || @@freebsd || @@darwin, msg)
     assert_respond_to(@mnt, :dump_frequency)
     assert_kind_of(Numeric, @mnt.dump_frequency)
   end
 
-  def test_freq_alias
+  test "mount freq is an alias for dump_frequency" do
     assert_respond_to(@mnt, :freq)
     assert_true(@mnt.method(:freq) == @mnt.method(:dump_frequency))
   end
 
-  def test_mount_pass_number
+  test "mount pass_number works as expected" do
     msg = 'pass_number test skipped on this platform'
     omit_if(@@solaris || @@freebsd || @@darwin, msg)
     assert_respond_to(@mnt, :pass_number)
     assert_kind_of(Numeric, @mnt.pass_number)
   end
 
-  def test_passno_alias
+  test "mount passno is an alias for pass_number" do
     assert_respond_to(@mnt, :passno)
     assert_true(@mnt.method(:passno) == @mnt.method(:pass_number))
   end
 
-  def test_mount_point_singleton
+  test "mount_point singleton method works as expected" do
     assert_respond_to(Filesystem, :mount_point)
     assert_nothing_raised{ Filesystem.mount_point(Dir.pwd) }
     assert_kind_of(String, Filesystem.mount_point(Dir.pwd))
   end
 
-  def test_ffi_functions_are_private
-    assert_false(Filesystem.methods.include?('statvfs'))
-    assert_false(Filesystem.methods.include?('strerror'))
-  end
-
-  def test_mount_singleton_method
+  test "mount singleton method is defined" do
     assert_respond_to(Sys::Filesystem, :mount)
   end
 
-  def test_umount_singleton_method
+  test "umount singleton method is defined" do
     assert_respond_to(Sys::Filesystem, :umount)
+  end
+
+  # FFI
+
+  test "ffi functions are private" do
+    assert_false(Filesystem.methods.include?('statvfs'))
+    assert_false(Filesystem.methods.include?('strerror'))
   end
 
   test "statfs struct is expected size" do

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -41,14 +41,14 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
     assert_kind_of(Numeric, @stat.block_size)
   end
 
-  test "stat block_size is a plausible value" do
-    assert_true(@stat.block_size >= 1024)
-    assert_true(@stat.block_size <= 16384)
-  end
-
   test "stat fragment_size works as expected" do
     assert_respond_to(@stat, :fragment_size)
     assert_kind_of(Numeric, @stat.fragment_size)
+  end
+
+  test "stat fragment_size is a plausible value" do
+    assert_true(@stat.fragment_size >= 512)
+    assert_true(@stat.fragment_size <= 16384)
   end
 
   test "stat blocks works as expected" do

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -27,7 +27,7 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
   end
 
   def test_version
-    assert_equal('1.3.0', Filesystem::VERSION)
+    assert_equal('1.3.1', Filesystem::VERSION)
     assert_true(Filesystem::VERSION.frozen?)
   end
 
@@ -293,9 +293,22 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
     assert_respond_to(Sys::Filesystem, :umount)
   end
 
-  test "structs are expected size" do
-    assert_equal(check_sizeof('struct statvfs', 'sys/statvfs.h'), Filesystem::Structs::Statvfs.size)
+  test "statfs struct is expected size" do
     assert_equal(check_sizeof('struct statfs', 'sys/statfs.h'), Filesystem::Structs::Statfs.size)
+  end
+
+  test "statvfs struct is expected size" do
+    assert_equal(check_sizeof('struct statvfs', 'sys/statvfs.h'), Filesystem::Structs::Statvfs.size)
+  end
+
+  test "mnttab struct is expected size" do
+    omit_unless(@@solaris, "mnttab test skipped except on Solaris")
+    assert_equal(check_sizeof('struct mnttab', 'sys/mnttab.h'), Filesystem::Structs::Mnttab.size)
+  end
+
+  test "mntent struct is expected size" do
+    omit_unless(@@linux, "mnttab test skipped except on Linux")
+    assert_equal(check_sizeof('struct mntent', 'mntent.h'), Filesystem::Structs::Mntent.size)
   end
 
   def teardown

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -296,8 +296,8 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
   end
 
   test "statfs struct is expected size" do
-    omit_if(@@darwin, "statfs test skipped on Darwin")
-    assert_equal(check_sizeof('struct statfs', 'sys/statfs.h'), Filesystem::Structs::Statfs.size)
+    header = @@freebsd || @@darwin ? 'sys/mount.h' : 'sys/statfs.h'
+    assert_equal(check_sizeof('struct statfs', header), Filesystem::Structs::Statfs.size)
   end
 
   test "statvfs struct is expected size" do

--- a/test/test_sys_filesystem_unix.rb
+++ b/test/test_sys_filesystem_unix.rb
@@ -294,6 +294,7 @@ class TC_Sys_Filesystem_Unix < Test::Unit::TestCase
   end
 
   test "statfs struct is expected size" do
+    omit_if(@@darwin, "statfs test skipped on Darwin")
     assert_equal(check_sizeof('struct statfs', 'sys/statfs.h'), Filesystem::Structs::Statfs.size)
   end
 

--- a/test/test_sys_filesystem_windows.rb
+++ b/test/test_sys_filesystem_windows.rb
@@ -20,7 +20,7 @@ class TC_Sys_Filesystem_Windows < Test::Unit::TestCase
   end
 
   test "version number is set to the expected value" do
-    assert_equal('1.3.0', Filesystem::VERSION)
+    assert_equal('1.3.1', Filesystem::VERSION)
     assert_true(Filesystem::VERSION.frozen?)
   end
 


### PR DESCRIPTION
Addresses https://github.com/djberg96/sys-filesystem/issues/35, plus some other cleanup.

Specifically:

* Fixes the Statvfs and Statfs wrapper structs for Linux.
* Some updates and fixes for BSD.
* Updated the unix tests to use the nicer description text (the windows tests were already updated).
* Added mkmf-lite as a development dependency.
* Added specs to ensure that the FFI wrapper struct is the same size as the underlying C struct.