### PR TITLE
Statvfs layout for i686 unix architectures

### DIFF
--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -123,6 +123,21 @@ module Sys
             :f_fstr, [:char, 32],
             :f_filler, [:ulong, 16]
           )
+        elsif RbConfig::CONFIG['host'] =~ /i686/i
+          layout(
+            :f_bsize, :ulong,
+            :f_frsize, :ulong,
+            :f_blocks, :uint,
+            :f_bfree, :uint,
+            :f_bavail, :uint,
+            :f_files, :uint,
+            :f_ffree, :uint,
+            :f_favail, :uint,
+            :f_fsid, :ulong,
+            :f_flag, :ulong,
+            :f_namemax, :ulong,
+            :f_spare, [:int, 6]
+          )
         else
           layout(
             :f_bsize, :ulong,


### PR DESCRIPTION
On Centos 6 and Debian 8, both i686 architectures Sys::FileSystem.stat returns invalid values:
```
irb(main):003:0> Sys::Filesystem::VERSION
=> "1.3.2"
irb(main):004:0> Sys::Filesystem.stat('/')
=> #<Sys::Filesystem::Stat:0x09295de8 @path="/", 
@block_size=4096, 
@fragment_size=4096, 
@blocks=18564931717193332, 
@blocks_free=5211753839214876, 
@blocks_available=4845603579311885, 
@files=2694623991, 
@files_free=1095216664576, 
@files_available=0, 
@filesystem_id=0, 
@flags=0, 
@name_max=0, 
@base_type=nil>
```
This happens because the Statvfs structure for unix systems has uint64_t value types instead of uint.
After the fix is applied, the stat method returns correct values:
```
irb(main):002:0> Sys::Filesystem.stat('/')
=> #<Sys::Filesystem::Stat:0x0a2da348 @path="/", 
@block_size=4096, 
@fragment_size=4096, 
@blocks=4742772, 
@blocks_free=4322484, 
@blocks_available=4079899, 
@files=1213456, 
@files_free=1128205, 
@files_available=1128205, 
@filesystem_id=2694623991, 
@flags=0, 
@name_max=4096, 
@base_type=nil>
``` 