### PR TITLE
Update for Big Sur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.4.1 - 30-Dec-2020
+* Fix an FFI function declaration bug for Big Sur and later on Mac. Thanks go
+  to Roman Gaufman for the spot and Martins Polakovs for testing.
+* Fixed the changelog metadata URI.
+* Added a .gitignore file.
+
 ## 1.4.0 - 6-Sep-2020
 * The Sys::Filesystem.stat method now accepts a Pathname and Dir object as
   an argument. On most platforms it will also accept a File object. Thanks

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A cross platform Ruby interface for getting file system information.
 
 ## Synopsis
 
-```
+```ruby
 require 'sys/filesystem'
 include Sys
    

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -1,7 +1,7 @@
 module Sys
   class Filesystem
     # The version of the sys-filesystem library
-    VERSION = '1.4.0'.freeze
+    VERSION = '1.4.1'.freeze
   end
 end
 

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -41,7 +41,11 @@ module Sys
         end
       rescue FFI::NotFoundError
         if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i
-          attach_function(:getmntinfo, :getmntinfo64, [:pointer, :int], :int)
+          begin
+            attach_function(:getmntinfo, :getmntinfo64, [:pointer, :int], :int)
+          rescue FFI::NotFoundError
+            attach_function(:getmntinfo, [:pointer, :int], :int) # Big Sur and later
+          end
         else
           attach_function(:getmntinfo, [:pointer, :int], :int)
         end

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Sys::Filesystem, :unix => true do
   end
 
   example "version number is set to the expected value" do
-    expect(Sys::Filesystem::VERSION).to eq('1.4.0')
+    expect(Sys::Filesystem::VERSION).to eq('1.4.1')
     expect(Sys::Filesystem::VERSION).to be_frozen
   end
 

--- a/spec/sys_filesystem_windows_spec.rb
+++ b/spec/sys_filesystem_windows_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Sys::Filesystem, :windows => true do
   end
 
   example "version number is set to the expected value" do
-    expect(Sys::Filesystem::VERSION).to eq('1.4.0')
+    expect(Sys::Filesystem::VERSION).to eq('1.4.1')
     expect(Sys::Filesystem::VERSION).to be_frozen
   end
 

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-filesystem'
-  spec.version    = '1.4.0'
+  spec.version    = '1.4.1'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     'homepage_uri'      => 'https://github.com/djberg96/sys-filesystem',
     'bug_tracker_uri'   => 'https://github.com/djberg96/sys-filesystem/issues',
-    'changelog_uri'     => 'https://github.com/djberg96/sys-filesystem/blob/ffi/CHANGES.rdoc',
+    'changelog_uri'     => 'https://github.com/djberg96/sys-filesystem/blob/ffi/CHANGES.md',
     'documentation_uri' => 'https://github.com/djberg96/sys-filesystem/wiki',
     'source_code_uri'   => 'https://github.com/djberg96/sys-filesystem',
     'wiki_uri'          => 'https://github.com/djberg96/sys-filesystem/wiki'


### PR DESCRIPTION
As of Big Sur, the `getmntinfo64` function is no longer exported, instead it simply uses a 64-bit version of `getmntinfo`. So this PR handles both situations, falling back to `getmntinfo` if `getmntinfo64` isn't found.

I also fixed a minor issue with the changelog URI, and added a .gitignore file.