### PR TITLE
Rubocop linter fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ CLEAN.include('**/*.gem', '**/*.rbc', '**/*.rbx', '**/*.lock')
 
 namespace :gem do
   desc "Build the sys-filesystem gem"
-  task :create => [:clean] do |t|
+  task :create => [:clean] do
     require 'rubygems/package'
     spec = eval(IO.read('sys-filesystem.gemspec'))
     spec.signing_key = File.join(Dir.home, '.ssh', 'gem-private_key.pem')
@@ -21,7 +21,7 @@ namespace :gem do
 end
 
 desc "Run the example program"
-task :example do |t|
+task :example do
   sh "ruby -Ilib -Ilib/unix -Ilib/windows examples/example_stat.rb"
 end
 

--- a/examples/example_mount.rb
+++ b/examples/example_mount.rb
@@ -7,11 +7,12 @@
 require 'optparse'
 
 options = {:mount_options => []}
+
 OptionParser.new do |opts|
   opts.banner = "Usage: #$0 [-o options] [-t external_type] special node"
 
-  opts.on("-o=OPTIONS",       "Set one or many mount options (comma delimited)") do |opts|
-    options[:mount_options] += opts.split(',')
+  opts.on("-o=OPTIONS",       "Set one or many mount options (comma delimited)") do |cli_opts|
+    options[:mount_options] += cli_opts.split(',')
   end
 
   opts.on("-r",               "Set readonly flag") do

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -11,8 +11,6 @@ module Sys
     include Sys::Filesystem::Structs
     extend Sys::Filesystem::Functions
 
-    private
-
     # Readable versions of constant names
     OPT_NAMES = {
       MNT_RDONLY           => 'read-only',
@@ -37,6 +35,8 @@ module Sys
       MNT_NOATIME          => 'noatime'
     }.freeze
 
+    private_constant :OPT_NAMES
+
     # File used to read mount informtion from.
     if File.exist?('/etc/mtab')
       MOUNT_FILE = '/etc/mtab'
@@ -48,7 +48,7 @@ module Sys
       MOUNT_FILE = 'getmntinfo'
     end
 
-    public
+    private_constant :MOUNT_FILE
 
     # The error raised if any of the Filesystem methods fail.
     class Error < StandardError; end
@@ -278,7 +278,7 @@ module Sys
 
         ptr = buf.get_pointer(0)
 
-        num.times{ |i|
+        num.times do
           mnt = Statfs.new(ptr)
           obj = Sys::Filesystem::Mount.new
           obj.name = mnt[:f_mntfromname].to_s
@@ -308,7 +308,7 @@ module Sys
           end
 
           ptr += Statfs.size
-        }
+        end
       else
         begin
           if respond_to?(:setmntent, true)

--- a/lib/sys/unix/sys/filesystem/constants.rb
+++ b/lib/sys/unix/sys/filesystem/constants.rb
@@ -1,8 +1,6 @@
 module Sys
   class Filesystem
     module Constants
-      private
-
       MNT_RDONLY      = 0x00000001 # read only filesystem
       MNT_SYNCHRONOUS = 0x00000002 # file system written synchronously
       MNT_NOEXEC      = 0x00000004 # can't exec from filesystem

--- a/lib/sys/windows/sys/filesystem.rb
+++ b/lib/sys/windows/sys/filesystem.rb
@@ -397,8 +397,6 @@ module Sys
       self
     end
 
-    private
-
     # This method is used to get the boot time of the system, which is used
     # for the mount_time attribute within the File.mounts method.
     #
@@ -411,13 +409,13 @@ module Sys
         raise Error, e
       else
         query = 'select LastBootupTime from Win32_OperatingSystem'
-        results = wmi.ExecQuery(query)
-        results.each{ |ole|
-          time_array = Time.parse(ole.LastBootupTime.split('.').first)
-          return Time.mktime(*time_array)
-        }
+        ole = wmi.ExecQuery(query).ItemIndex(0)
+        time_array = Time.parse(ole.LastBootupTime.split('.').first)
+        Time.mktime(*time_array)
       end
     end
+
+    private_class_method :get_boot_time
 
     # Private method that converts filesystem flags into a comma separated
     # list of strings. The presentation is meant as a rough analogue to the
@@ -439,8 +437,9 @@ module Sys
        str << " compressed" if VOLUME_IS_COMPRESSED & flags > 0
 
        str.tr!(' ', ',')
-       str = str[1..-1] # Ignore the first comma
-       str
+       str[1..-1] # Ignore the first comma
     end
+
+    private_class_method :get_options
   end
 end


### PR DESCRIPTION
Fixes some unused variables, as well as fixing some private access modifiers and/or removing useless ones.