### PR TITLE
Fix require and update specs in unix example group, update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,3 @@
 source 'https://rubygems.org' do
-  gem 'ffi', '~> 1.1'
-  group 'test' do
-    gem 'mkmf-lite', '~> 0.4'
-    gem 'rake'
-    gem 'rspec', '~> 3.9'
-    gem 'fakefs', '~> 1.2'
-  end
+  gemspec
 end

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -359,8 +359,11 @@ RSpec.describe Sys::Filesystem, :unix => true do
   end
 
   context "FFI" do
-    require 'mkmf-lite'
-    include Mkmf::Lite
+    before(:context) do
+      require 'mkmf-lite'
+    end
+
+    let(:dummy) { Class.new { extend Mkmf::Lite } }
 
     example "ffi functions are private" do
       expect(Sys::Filesystem.methods.include?('statvfs')).to be false
@@ -369,21 +372,21 @@ RSpec.describe Sys::Filesystem, :unix => true do
 
     example "statfs struct is expected size" do
       header = bsd || darwin ? 'sys/mount.h' : 'sys/statfs.h'
-      expect(Sys::Filesystem::Structs::Statfs.size).to eq(check_sizeof('struct statfs', header))
+      expect(Sys::Filesystem::Structs::Statfs.size).to eq(dummy.check_sizeof('struct statfs', header))
     end
 
     example "statvfs struct is expected size" do
-      expect(Sys::Filesystem::Structs::Statvfs.size).to eq(check_sizeof('struct statvfs', 'sys/statvfs.h'))
+      expect(Sys::Filesystem::Structs::Statvfs.size).to eq(dummy.check_sizeof('struct statvfs', 'sys/statvfs.h'))
     end
 
     example "mnttab struct is expected size" do
       skip "mnttab test skipped except on Solaris" unless solaris
-      expect(Sys::Filesystem::Structs::Mnttab.size).to eq(check_sizeof('struct mnttab', 'sys/mnttab.h'))
+      expect(Sys::Filesystem::Structs::Mnttab.size).to eq(dummy.check_sizeof('struct mnttab', 'sys/mnttab.h'))
     end
 
     example "mntent struct is expected size" do
       skip "mnttab test skipped except on Linux" unless linux
-      expect(Sys::Filesystem::Structs::Mntent.size).to eq(check_sizeof('struct mntent', 'mntent.h'))
+      expect(Sys::Filesystem::Structs::Mntent.size).to eq(dummy.check_sizeof('struct mntent', 'mntent.h'))
     end
   end
 end

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.cert_chain = Dir['certs/*']
    
   spec.add_dependency('ffi', '~> 1.1')
-  spec.add_development_dependency('mkmf-lite', '~> 0.4')
+  spec.add_development_dependency('mkmf-lite', '~> 0.5') unless Gem.win_platform?
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec', '~> 3.9')
 


### PR DESCRIPTION
This fixes a few issues that were revealed by github actions, and changes some things around. Namely:

* Just use the gemspec for the Gemfile, it's easier and I had accidentally left fakefs in there.
* Only require mkmf-lite on non-Windows platforms.
* Fixes an issue where rspec was evaluating a require statement in the Unix spec on Windows that would fail.