### PR TITLE
Do not use statvfs64 on 32 bits linux

### DIFF
--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -7,7 +7,7 @@ module Sys
 
       ffi_lib FFI::Library::LIBC
 
-      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris|linux/i
+      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris|x86_64.*linux/i
         attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
       else
         attach_function(:statvfs, %i[string pointer], :int)


### PR DESCRIPTION
The commit https://github.com/djberg96/sys-filesystem/commit/4024d9569cc11841f605bb9f5e74e42c32f2082e causes crash on 32 bits Linux, we should use `statvfs64` only on 64 bits Linux