### PR TITLE
Handle 32-bit Linux properly

### DIFF
--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -7,7 +7,9 @@ module Sys
 
       ffi_lib FFI::Library::LIBC
 
-      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris|_64.*linux/i
+      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
+        attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
+      elsif RbConfig::CONFIG['host_os'] =~ /linux/i && RbConfig::CONFIG['arch'] =~ /64/
         attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
       else
         attach_function(:statvfs, %i[string pointer], :int)

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -7,7 +7,7 @@ module Sys
 
       ffi_lib FFI::Library::LIBC
 
-      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris|linux/i
+      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris|_64.*linux/i
         attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
       else
         attach_function(:statvfs, %i[string pointer], :int)

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -40,7 +40,7 @@ module Sys
             :f_mntonname, [:char, MNAMELEN]
           )
         elsif RbConfig::CONFIG['host_os'] =~ /linux/i
-          if RbConfig::CONFIG['host_os'] =~ /64/
+          if RbConfig::CONFIG['arch'] =~ /64/
             layout(
               :f_type, :ulong,
               :f_bsize, :ulong,

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -40,20 +40,37 @@ module Sys
             :f_mntonname, [:char, MNAMELEN]
           )
         elsif RbConfig::CONFIG['host_os'] =~ /linux/i
-          layout(
-            :f_type, :ulong,
-            :f_bsize, :ulong,
-            :f_blocks, :uint64,
-            :f_bfree, :uint64,
-            :f_bavail, :uint64,
-            :f_files, :uint64,
-            :f_ffree, :uint64,
-            :f_fsid, [:int, 2],
-            :f_namelen, :ulong,
-            :f_frsize, :ulong,
-            :f_flags, :ulong,
-            :f_spare, [:ulong, 4]
-          )
+          if RbConfig::CONFIG['host_os'] =~ /64/
+            layout(
+              :f_type, :ulong,
+              :f_bsize, :ulong,
+              :f_blocks, :uint64,
+              :f_bfree, :uint64,
+              :f_bavail, :uint64,
+              :f_files, :uint64,
+              :f_ffree, :uint64,
+              :f_fsid, [:int, 2],
+              :f_namelen, :ulong,
+              :f_frsize, :ulong,
+              :f_flags, :ulong,
+              :f_spare, [:ulong, 4]
+            )
+          else
+            layout(
+              :f_type, :ulong,
+              :f_bsize, :ulong,
+              :f_blocks, :uint32,
+              :f_bfree, :uint32,
+              :f_bavail, :uint32,
+              :f_files, :uint32,
+              :f_ffree, :uint32,
+              :f_fsid, [:int, 2],
+              :f_namelen, :ulong,
+              :f_frsize, :ulong,
+              :f_flags, :ulong,
+              :f_spare, [:ulong, 4]
+            )
+          end
         else
           layout(
             :f_bsize, :uint32,
@@ -134,6 +151,7 @@ module Sys
             :f_ffree, :uint,
             :f_favail, :uint,
             :f_fsid, :ulong,
+            :f_unused, :int,
             :f_flag, :ulong,
             :f_namemax, :ulong,
             :f_spare, [:int, 6]


### PR DESCRIPTION
Handle 32-bit Linux properly. This means not using 64-bit functions, and using the appropriate struct.

Tested locally on Ubuntu 16, Fedora 34 and RHEL 8.

Replacement for https://github.com/djberg96/sys-filesystem/pull/56

