### PR TITLE
Use 1.size instead of checking host_os

### DIFF
--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -9,7 +9,7 @@ module Sys
 
       if RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
         attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
-      elsif RbConfig::CONFIG['host_os'] =~ /linux/i && RbConfig::CONFIG['arch'] =~ /64/
+      elsif RbConfig::CONFIG['host_os'] =~ /linux/i && 1.size == 8
         attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
       else
         attach_function(:statvfs, %i[string pointer], :int)

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -40,7 +40,7 @@ module Sys
             :f_mntonname, [:char, MNAMELEN]
           )
         elsif RbConfig::CONFIG['host_os'] =~ /linux/i
-          if RbConfig::CONFIG['arch'] =~ /64/
+          if 1.size == 8
             layout(
               :f_type, :ulong,
               :f_bsize, :ulong,


### PR DESCRIPTION
Followup to https://github.com/djberg96/sys-filesystem/pull/57 to try and solve https://github.com/djberg96/sys-filesystem/issues/58

In short, we can't rely on host OS info because it might not include the architecture information we need. And, I think we actually care more about the process itself than the OS. So, I've changed it to check against `1.size` instead which is 8 on a 64 bit process. This seems to work with JRuby as well.