### PR TITLE
Add shared examples, refactor specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'rspec'
+require 'sys_filesystem_shared'
 
 RSpec.configure do |config|
+  config.include_context(Sys::Filesystem)
   config.filter_run_excluding(:windows) unless Gem.win_platform?
   config.filter_run_excluding(:unix) if Gem.win_platform?
 end

--- a/spec/sys_filesystem_shared.rb
+++ b/spec/sys_filesystem_shared.rb
@@ -1,0 +1,12 @@
+require 'sys-filesystem'
+
+RSpec.shared_examples Sys::Filesystem do
+  example 'version number is set to the expected value' do
+    expect(Sys::Filesystem::VERSION).to eq('1.4.3')
+    expect(Sys::Filesystem::VERSION).to be_frozen
+  end
+
+  example 'you cannot instantiate an instance' do
+    expect{ described_class.new }.to raise_error(NoMethodError)
+  end
+end

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -20,15 +20,6 @@ RSpec.describe Sys::Filesystem, :unix => true do
     @size  = 58720256
   end
 
-  example 'version number is set to the expected value' do
-    expect(Sys::Filesystem::VERSION).to eq('1.4.3')
-    expect(Sys::Filesystem::VERSION).to be_frozen
-  end
-
-  example 'you cannot instantiate an instance' do
-    expect{ described_class.new }.to raise_error(NoMethodError)
-  end
-
   example 'stat path works as expected' do
     expect(@stat).to respond_to(:path)
     expect(@stat.path).to eq(root)

--- a/spec/sys_filesystem_windows_spec.rb
+++ b/spec/sys_filesystem_windows_spec.rb
@@ -16,15 +16,6 @@ RSpec.describe Sys::Filesystem, :windows => true do
     @size  = 58720256
   end
 
-  example 'version number is set to the expected value' do
-    expect(Sys::Filesystem::VERSION).to eq('1.4.3')
-    expect(Sys::Filesystem::VERSION).to be_frozen
-  end
-
-  example 'you cannot instantiate an instance' do
-    expect{ described_class.new }.to raise_error(NoMethodError)
-  end
-
   example 'stat path works as expected' do
     expect(@stat).to respond_to(:path)
     expect(@stat.path).to eq(root)


### PR DESCRIPTION
This lets a couple of common tests be run for either platform automatically instead of having them copy/pasted, which can be error prone.