### PR TITLE
Fix segfault when calling statvfs on 32-bit linux

### DIFF
--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -110,6 +110,16 @@ module Sys
 
       # The Statvfs struct represents struct statvfs from sys/statvfs.h.
       class Statvfs < FFI::Struct
+        # Private method that will determine the layout of the struct on Linux.
+        def self.linux64?
+          if RUBY_PLATFORM == 'java'
+            ENV_JAVA['sun.arch.data.model'].to_i == 64
+          else
+            RbConfig::CONFIG['host_os'] =~ /linux/i &&
+              (RbConfig::CONFIG['arch'] =~ /64/ || RbConfig::CONFIG['DEFS'] =~ /64/)
+          end
+        end
+
         if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i
           layout(
             :f_bsize, :ulong,
@@ -155,7 +165,7 @@ module Sys
             :f_fstr, [:char, 32],
             :f_filler, [:ulong, 16]
           )
-        elsif RbConfig::CONFIG['host'] =~ /i686/i
+        elsif !linux64?
           layout(
             :f_bsize, :ulong,
             :f_frsize, :ulong,


### PR DESCRIPTION
On 32-bit linux, ruby's configure script detects that FILE_OFFSET_BITS=64 is required to access the 64-bit filesystem interface and adds the following to rbconfig.rb:

    CONFIG["DEFS"] = "-D_FILE_OFFSET_BITS=64"

The sys-filesystem gem was modified in 68d6cdb978d4d25b25d9eafa5e1e5b5642e88578 to detect that case and call the 64-bit version of `statvfs`. The `Statfs` struct was also modified, but the similarly named `Statvfs` struct wasn't. So the following segfaulted on 32-bit linux:

    $ ruby -rsys-filesystem -e "Sys::Filesystem.stat('/')"
    *** glibc detected *** /opt/puppetlabs/puppet/bin/ruby: double free or corruption (!prev): 0x094b1c58 ***