### PR TITLE
Handle possibility that statvfs64 doesn't exist on 64-bit platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 1.4.5 - 22-May-2024
+* Handle the possibility that a statvs64 alias may not exist on some Linux
+  platforms. Thanks go to Antoine Martin for the report.
+
 ## 1.4.4 - 12-Sep-2023
 * Yet another fix for 32-bit vs 64-bit linux, specifically for the Statvfs
   struct. Thanks go to Josh Cooper for the spot and the patch.

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -16,7 +16,7 @@ module Sys
   # return objects of other types. Do not instantiate.
   class Filesystem
     # The version of the sys-filesystem library
-    VERSION = '1.4.4'
+    VERSION = '1.4.5'
 
     # Stat objects are returned by the Sys::Filesystem.stat method. Here
     # we're adding universal methods.

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -27,7 +27,11 @@ module Sys
       private_class_method :linux64?
 
       if linux64? || solaris?
-        attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
+        begin
+          attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
+        rescue FFI::NotFoundError # Not every Linux distro has an alias
+          attach_function(:statvfs, %i[string pointer], :int)
+        end
       else
         attach_function(:statvfs, %i[string pointer], :int)
       end

--- a/spec/sys_filesystem_shared.rb
+++ b/spec/sys_filesystem_shared.rb
@@ -4,7 +4,7 @@ require 'sys-filesystem'
 
 RSpec.shared_examples Sys::Filesystem do
   example 'version number is set to the expected value' do
-    expect(Sys::Filesystem::VERSION).to eq('1.4.4')
+    expect(Sys::Filesystem::VERSION).to eq('1.4.5')
     expect(Sys::Filesystem::VERSION).to be_frozen
   end
 

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -503,5 +503,10 @@ RSpec.describe Sys::Filesystem, :unix => true do
       msg = 'statvfs() function failed: No such file or directory'
       expect{ described_class.stat('/whatever') }.to raise_error(Sys::Filesystem::Error, msg)
     end
+
+    example 'statvfs alias is used for statvfs64' do
+      expect(Sys::Filesystem::Functions.attached_functions[:statvfs]).to be_a(FFI::Function)
+      expect(Sys::Filesystem::Functions.attached_functions[:statvfs64]).to be_nil
+    end
   end
 end

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-filesystem'
-  spec.version    = '1.4.4'
+  spec.version    = '1.4.5'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'


### PR DESCRIPTION
Apparently not all 64-bit Linux distros have a statvfs64 function or alias.

Addresses https://github.com/djberg96/sys-filesystem/issues/66