### PR TITLE
Add Dragonflybsd support, refactor umount

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 1.5.0 - ???
+## 1.5.0 - 8-Jun-2024
 * Add support for DragonFlyBSD.
 * Remove Solaris support. It's dead, Jim.
 * Now assumes umount2 function is present on Linux systems, and some

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ## 1.5.0 - ???
 * Add support for DragonFlyBSD.
 * Remove Solaris support. It's dead, Jim.
-* Now assumes umount2 is present on Linux systems.
+* Now assumes umount2 function is present on Linux systems, and some
+  corresponding refactoring of the umount method.
 
 ## 1.4.5 - 22-May-2024
 * Handle the possibility that a statvs64 alias may not exist on some Linux

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 1.5.0 - ???
+* Add support for DragonFlyBSD.
+* Remove Solaris support. It's dead, Jim.
+* Now assumes umount2 is present on Linux systems.
+
 ## 1.4.5 - 22-May-2024
 * Handle the possibility that a statvs64 alias may not exist on some Linux
   platforms. Thanks go to Antoine Martin for the report.

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -16,7 +16,7 @@ module Sys
   # return objects of other types. Do not instantiate.
   class Filesystem
     # The version of the sys-filesystem library
-    VERSION = '1.4.5'
+    VERSION = '1.5.0'
 
     # Stat objects are returned by the Sys::Filesystem.stat method. Here
     # we're adding universal methods.

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -105,6 +105,27 @@ module Sys
       # The filesystem type, e.g. UFS.
       attr_accessor :base_type
 
+      # The filesystem ID
+      attr_accessor :filesystem_id
+
+      # The filesystem type
+      attr_accessor :filesystem_type
+
+      # The user that mounted the filesystem
+      attr_accessor :owner
+
+      # Count of sync reads since mount
+      attr_accessor :sync_reads
+
+      # Count of sync writes since mount
+      attr_accessor :sync_writes
+
+      # Count of async reads since mount
+      attr_accessor :async_reads
+
+      # Count of async writes since mount
+      attr_accessor :async_writes
+
       alias inodes files
       alias inodes_free files_free
       alias inodes_available files_available
@@ -248,6 +269,16 @@ module Sys
 
       if fs.members.include?(:f_basetype)
         obj.base_type = fs[:f_basetype].to_s
+      end
+
+      # DragonFlyBSD has additional struct members
+      if RbConfig::CONFIG['host_os'] =~ /dragonfly/i
+        obj.owner = fs[:f_owner]
+        obj.filesystem_type = fs[:f_type]
+        obj.sync_reads= fs[:f_syncreads]
+        obj.async_reads= fs[:f_asyncreads]
+        obj.sync_writes = fs[:f_syncwrites]
+        obj.async_writes = fs[:f_asyncwrites]
       end
 
       obj.freeze

--- a/lib/sys/unix/sys/filesystem/constants.rb
+++ b/lib/sys/unix/sys/filesystem/constants.rb
@@ -25,6 +25,8 @@ module Sys
       MNT_DEFWRITE    = 0x02000000 # filesystem should defer writes
       MNT_MULTILABEL  = 0x04000000 # MAC support for individual labels
       MNT_NOATIME     = 0x10000000 # disable update of file access time
+      MNT_NOCLUSTERR  = 0x40000000 # disable cluster read
+      MNT_NOCLUSTERW  = 0x80000000 # disable cluster write
 
       MNT_VISFLAGMASK = (
         MNT_RDONLY | MNT_SYNCHRONOUS | MNT_NOEXEC |

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -20,13 +20,9 @@ module Sys
         end
       end
 
-      def self.solaris?
-        RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
-      end
-
       private_class_method :linux64?
 
-      if linux64? || solaris?
+      if linux64?
         begin
           attach_function(:statvfs, :statvfs64, %i[string pointer], :int)
         rescue FFI::NotFoundError # Not every Linux distro has an alias
@@ -52,17 +48,10 @@ module Sys
       private_class_method :statvfs, :strerror, :mount_c, :umount_c
 
       begin
-        if RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
-          attach_function(:fopen, %i[string string], :pointer)
-          attach_function(:fclose, [:pointer], :int)
-          attach_function(:getmntent, %i[pointer pointer], :int)
-          private_class_method :fopen, :fclose, :getmntent
-        else
-          attach_function(:getmntent, [:pointer], :pointer)
-          attach_function(:setmntent, %i[string string], :pointer)
-          attach_function(:endmntent, [:pointer], :int)
-          private_class_method :getmntent, :setmntent, :endmntent
-        end
+        attach_function(:getmntent, [:pointer], :pointer)
+        attach_function(:setmntent, %i[string string], :pointer)
+        attach_function(:endmntent, [:pointer], :int)
+        private_class_method :getmntent, :setmntent, :endmntent
       rescue FFI::NotFoundError
         if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i
           begin

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -36,7 +36,7 @@ module Sys
       attach_function(:mount_c, :mount, %i[string string string ulong string], :int)
 
       if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd|dragonfly/i
-        attach_function(:umount_c, :unmount, [:string], :int)
+        attach_function(:umount_c, :unmount, %i[string int], :int)
       else
         attach_function(:umount_c, :umount2, %i[string int], :int)
       end

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -35,14 +35,10 @@ module Sys
       attach_function(:strerror, [:int], :string)
       attach_function(:mount_c, :mount, %i[string string string ulong string], :int)
 
-      begin
+      if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd|dragonfly/i
+        attach_function(:umount_c, :unmount, [:string], :int)
+      else
         attach_function(:umount_c, :umount2, %i[string int], :int)
-      rescue FFI::NotFoundError
-        if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd|dragonfly/i
-          attach_function(:umount_c, :unmount, [:string], :int)
-        else
-          attach_function(:umount_c, :umount, [:string], :int)
-        end
       end
 
       private_class_method :statvfs, :strerror, :mount_c, :umount_c

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -40,10 +40,12 @@ module Sys
       attach_function(:mount_c, :mount, %i[string string string ulong string], :int)
 
       begin
-        attach_function(:umount_c, :umount, [:string], :int)
+        attach_function(:umount_c, :umount2, %i[string int], :int)
       rescue FFI::NotFoundError
-        if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd/i
+        if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd|dragonfly/i
           attach_function(:umount_c, :unmount, [:string], :int)
+        else
+          attach_function(:umount_c, :umount, [:string], :int)
         end
       end
 
@@ -59,8 +61,7 @@ module Sys
           attach_function(:getmntent, [:pointer], :pointer)
           attach_function(:setmntent, %i[string string], :pointer)
           attach_function(:endmntent, [:pointer], :int)
-          attach_function(:umount2, %i[string int], :int)
-          private_class_method :getmntent, :setmntent, :endmntent, :umount2
+          private_class_method :getmntent, :setmntent, :endmntent
         end
       rescue FFI::NotFoundError
         if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -182,17 +182,6 @@ module Sys
         end
       end
 
-      # The Mnttab struct represents struct mnnttab from sys/mnttab.h on Solaris.
-      class Mnttab < FFI::Struct
-        layout(
-          :mnt_special, :string,
-          :mnt_mountp, :string,
-          :mnt_fstype, :string,
-          :mnt_mntopts, :string,
-          :mnt_time, :string
-        )
-      end
-
       # The Mntent struct represents struct mntent from sys/mount.h on Unix.
       class Mntent < FFI::Struct
         layout(

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -6,6 +6,20 @@ require 'rbconfig'
 module Sys
   class Filesystem
     module Structs
+      # Used by DragonFlyBSD
+      class UUID < FFI::Struct
+        UUID_NODE_LEN = 6
+
+        layout(
+          :time_low, :uint32,
+          :time_mid, :uint16,
+          :time_hi_and_version, :uint16,
+          :clock_seq_hi_and_reserved, :uint8,
+          :clock_seq_low, :uint8,
+          :node, [:uint8, UUID_NODE_LEN]
+        )
+      end
+
       # The Statfs struct is a subclass of FFI::Struct that corresponds to a struct statfs.
       class Statfs < FFI::Struct
         # Private method that will determine the layout of the struct on Linux.
@@ -172,6 +186,28 @@ module Sys
             :f_frsize, :ulong,
             :f_fsid, :ulong,
             :f_namemax, :ulong
+          )
+        elsif RbConfig::CONFIG['host'] =~ /dragonfly/i
+          layout(
+            :f_bsize, :ulong,
+            :f_frsize, :ulong,
+            :f_blocks, :uint64,
+            :f_bfree, :uint64,
+            :f_bavail, :uint64,
+            :f_files, :uint64,
+            :f_ffree, :uint64,
+            :f_favail, :uint64,
+            :f_fsid, :ulong,
+            :f_flag, :ulong,
+            :f_namemax, :ulong,
+            :f_owner, :uid_t,
+            :f_type, :uint,
+            :f_syncreads, :uint64,
+            :f_syncwrites, :uint64,
+            :f_asyncreads, :uint64,
+            :f_asyncwrites, :uint64,
+            :f_fsid_uuid, UUID,
+            :f_uid_uuid, UUID
           )
         elsif !linux64?
           layout(

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -148,23 +148,6 @@ module Sys
             :f_fsid, :ulong,
             :f_namemax, :ulong
           )
-        elsif RbConfig::CONFIG['host'] =~ /sunos|solaris/i
-          layout(
-            :f_bsize, :ulong,
-            :f_frsize, :ulong,
-            :f_blocks, :uint64_t,
-            :f_bfree, :uint64_t,
-            :f_bavail, :uint64_t,
-            :f_files, :uint64_t,
-            :f_ffree, :uint64_t,
-            :f_favail, :uint64_t,
-            :f_fsid, :ulong,
-            :f_basetype, [:char, 16],
-            :f_flag, :ulong,
-            :f_namemax, :ulong,
-            :f_fstr, [:char, 32],
-            :f_filler, [:ulong, 16]
-          )
         elsif !linux64?
           layout(
             :f_bsize, :ulong,

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -86,6 +86,31 @@ module Sys
                 :f_spare, [:ulong, 4]
               )
             end
+          when /dragonfly/i
+            layout(
+              :f_spare2, :long,
+              :f_bsize, :long,
+              :f_iosize, :long,
+              :f_blocks, :long,
+              :f_bfree, :long,
+              :f_bavail, :long,
+              :f_files, :long,
+              :f_ffree, :long,
+              :f_fsid, [:int32_t, 2],
+              :f_owner, :uid_t,
+              :f_type, :int,
+              :f_flags, :int,
+              :f_syncwrites, :long,
+              :f_asyncwrites, :long,
+              :f_fstypename, [:char, 16],
+              :f_mntonname, [:char, 80],
+              :f_syncreads, :long,
+              :f_asyncreads, :long,
+              :f_spares1, :short,
+              :f_mntfromname, [:char, 80],
+              :f_spares2, :short,
+              :f_spare, [:long,2]
+            )
           else
             layout(
               :f_bsize, :uint32,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,4 +7,5 @@ RSpec.configure do |config|
   config.include_context(Sys::Filesystem)
   config.filter_run_excluding(:windows) unless Gem.win_platform?
   config.filter_run_excluding(:unix) if Gem.win_platform?
+  config.filter_run_excluding(:dragonfly) unless RbConfig::CONFIG['host_os'] =~ /dragonfly/i
 end

--- a/spec/sys_filesystem_shared.rb
+++ b/spec/sys_filesystem_shared.rb
@@ -4,7 +4,7 @@ require 'sys-filesystem'
 
 RSpec.shared_examples Sys::Filesystem do
   example 'version number is set to the expected value' do
-    expect(Sys::Filesystem::VERSION).to eq('1.4.5')
+    expect(Sys::Filesystem::VERSION).to eq('1.5.0')
     expect(Sys::Filesystem::VERSION).to be_frozen
   end
 

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Sys::Filesystem, :unix => true do
 
   example 'stat fragment_size is a plausible value' do
     expect(@stat.fragment_size).to be >= 512
-    expect(@stat.fragment_size).to be <= 16384
+    expect(@stat.fragment_size).to be <= 2**16
+    expect(@stat.fragment_size).to be >= @stat.block_size
   end
 
   example 'stat blocks works as expected' do
@@ -99,6 +100,38 @@ RSpec.describe Sys::Filesystem, :unix => true do
   example 'stat name_max works as expected' do
     expect(@stat).to respond_to(:name_max)
     expect(@stat.name_max).to be_a(Numeric)
+  end
+
+  context 'dragonfly', :dragonfly do
+    example 'owner works as expected' do
+      expect(@stat).to respond_to(:owner)
+      expect(@stat.owner).to be_a(Numeric)
+    end
+
+    example 'filesystem_type works as expected' do
+      expect(@stat).to respond_to(:filesystem_type)
+      expect(@stat.filesystem_type).to be_a(Numeric)
+    end
+
+    example 'sync_reads works as expected' do
+      expect(@stat).to respond_to(:sync_reads)
+      expect(@stat.sync_reads).to be_a(Numeric)
+    end
+
+    example 'async_reads works as expected' do
+      expect(@stat).to respond_to(:async_reads)
+      expect(@stat.async_reads).to be_a(Numeric)
+    end
+
+    example 'sync_writes works as expected' do
+      expect(@stat).to respond_to(:sync_writes)
+      expect(@stat.sync_writes).to be_a(Numeric)
+    end
+
+    example 'async_writes works as expected' do
+      expect(@stat).to respond_to(:async_writes)
+      expect(@stat.async_writes).to be_a(Numeric)
+    end
   end
 
   example 'stat constants are defined' do

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -12,7 +12,7 @@ require 'pathname'
 
 RSpec.describe Sys::Filesystem, :unix => true do
   let(:linux)   { RbConfig::CONFIG['host_os'] =~ /linux/i }
-  let(:bsd)     { RbConfig::CONFIG['host_os'] =~ /bsd/i }
+  let(:bsd)     { RbConfig::CONFIG['host_os'] =~ /bsd|dragonfly/i }
   let(:darwin)  { RbConfig::CONFIG['host_os'] =~ /mac|darwin/i }
   let(:root)    { '/' }
 

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Sys::Filesystem, :unix => true do
   example 'stat fragment_size is a plausible value' do
     expect(@stat.fragment_size).to be >= 512
     expect(@stat.fragment_size).to be <= 2**16
-    expect(@stat.fragment_size).to be >= @stat.block_size
+    expect(@stat.fragment_size).to be <= @stat.block_size
   end
 
   example 'stat blocks works as expected' do

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -11,7 +11,6 @@ require 'sys-filesystem'
 require 'pathname'
 
 RSpec.describe Sys::Filesystem, :unix => true do
-  let(:solaris) { RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i }
   let(:linux)   { RbConfig::CONFIG['host_os'] =~ /linux/i }
   let(:bsd)     { RbConfig::CONFIG['host_os'] =~ /bsd/i }
   let(:darwin)  { RbConfig::CONFIG['host_os'] =~ /mac|darwin/i }
@@ -102,21 +101,9 @@ RSpec.describe Sys::Filesystem, :unix => true do
     expect(@stat.name_max).to be_a(Numeric)
   end
 
-  example 'stat base_type works as expected' do
-    skip 'base_type test skipped except on Solaris' unless solaris
-
-    expect(@stat).to respond_to(:base_type)
-    expect(@stat.base_type).to be_a(String)
-  end
-
   example 'stat constants are defined' do
     expect(Sys::Filesystem::Stat::RDONLY).not_to be_nil
     expect(Sys::Filesystem::Stat::NOSUID).not_to be_nil
-  end
-
-  example 'stat constants for solaris are defined' do
-    skip 'NOTRUNC test skipped except on Solaris' unless solaris
-    expect(Sys::Filesystem::Stat::NOTRUNC).not_to be_nil
   end
 
   example 'stat bytes_total works as expected' do
@@ -423,15 +410,15 @@ RSpec.describe Sys::Filesystem, :unix => true do
       expect(mount.method(:opts)).to eq(mount.method(:options))
     end
 
+    # This method may be removed
     example 'mount time works as expected' do
-      expected_class = solaris ? Time : NilClass
       expect(mount).to respond_to(:mount_time)
-      expect(mount.mount_time).to be_a(expected_class)
+      expect(mount.mount_time).to be_nil
     end
 
     example 'mount dump_frequency works as expected' do
       msg = 'dump_frequency test skipped on this platform'
-      skip msg if solaris || bsd || darwin
+      skip msg if bsd || darwin
       expect(mount).to respond_to(:dump_frequency)
       expect(mount.dump_frequency).to be_a(Numeric)
     end
@@ -443,7 +430,7 @@ RSpec.describe Sys::Filesystem, :unix => true do
 
     example 'mount pass_number works as expected' do
       msg = 'pass_number test skipped on this platform'
-      skip msg if solaris || bsd || darwin
+      skip msg if bsd || darwin
       expect(mount).to respond_to(:pass_number)
       expect(mount.pass_number).to be_a(Numeric)
     end
@@ -487,11 +474,6 @@ RSpec.describe Sys::Filesystem, :unix => true do
 
     example 'statvfs struct is expected size' do
       expect(Sys::Filesystem::Structs::Statvfs.size).to eq(dummy.check_sizeof('struct statvfs', 'sys/statvfs.h'))
-    end
-
-    example 'mnttab struct is expected size' do
-      skip 'mnttab test skipped except on Solaris' unless solaris
-      expect(Sys::Filesystem::Structs::Mnttab.size).to eq(dummy.check_sizeof('struct mnttab', 'sys/mnttab.h'))
     end
 
     example 'mntent struct is expected size' do

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-filesystem'
-  spec.version    = '1.4.5'
+  spec.version    = '1.5.0'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'


### PR DESCRIPTION
The primary purpose of this PR is to add DragonFlyBSD support. Note that it was tested with the HAMMER2 filesystem, I'm not sure if it works with a standard UFS filesystem, but it appears to be the default so I went with it.

I also updated the `umount` method, which now assumes that the `umount2` function is defined on Linux systems. This simplified the implementation of the corresponding Ruby method.

Last, I decided to finally remove Solaris support. It's dead.