### PR TITLE
Add f_type field to struct statvfs

### DIFF
--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -223,7 +223,8 @@ module Sys
             :f_unused, :int,
             :f_flag, :ulong,
             :f_namemax, :ulong,
-            :f_spare, [:int, 6]
+            :f_type, :uint,
+            :f_spare, [:int, 5]
           )
         else
           layout(
@@ -238,7 +239,8 @@ module Sys
             :f_fsid, :ulong,
             :f_flag, :ulong,
             :f_namemax, :ulong,
-            :f_spare, [:int, 6]
+            :f_type, :uint,
+            :f_spare, [:int, 5]
           )
         end
       end


### PR DESCRIPTION
It's been added in both glibc and musl. Glibc has been zeroing out the spare ints since the dawn of time and musl since at least 1.0.0, so it's safe to simply check if these values are nonzero.

https://github.com/bminor/glibc/commit/92861d93cdad13834f4d8f39504b550a80ad8200

https://github.com/bminor/musl/commit/7291c6c66a8d033bb487e6d8c8b003c8a7b6a550