### PR TITLE
Add padding on 32 bit statvfs with 64 bit offsets

### DIFF
--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -227,7 +227,9 @@ module Sys
             :f_spare, [:int, 5]
           )
         else
-          layout(
+          require 'mkmf-lite'
+          extend Mkmf::Lite
+          layout_array = [
             :f_bsize, :ulong,
             :f_frsize, :ulong,
             :f_blocks, :uint64,
@@ -241,7 +243,16 @@ module Sys
             :f_namemax, :ulong,
             :f_type, :uint,
             :f_spare, [:int, 5]
-          )
+          ]
+
+          # Check if we need to add __f_unused
+          f_unused_bytes = 2 * check_sizeof('int') - check_sizeof('long')
+          if f_unused_bytes > 0
+            # For Big Endian, this should be inserted at -9
+            layout_array.insert(-7, :__f_unused, [:char, f_unused_bytes])
+          end
+
+          layout(*layout_array)
         end
       end
 


### PR DESCRIPTION
Effectively does what musl does, which also works for glibc.

Closes #71