### PR TITLE
Update for 1.5.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 1.5.3 - 3-Oct-2024
+* Decided to unroll the changes in 1.5.2 because doing runtime compiler
+  checks was making more people unhappy than happy, and I already had
+  some misgivings about it.
+* Updated the README.md to note the issues with running 32-bit Ruby with
+  64-bit offsets. At the moment I think this mainly only affects arch Linux.
+
 ## 1.5.2 - 30-Sep-2024
 * Forgot to switch mkmf-lite from a dev dependency to a runtime dependency.
   Thanks go to Thomas Langé for the spot and patch.

--- a/README.md
+++ b/README.md
@@ -55,16 +55,19 @@ with JRuby, too.
 Run 'rake example' if you want to see a basic sample run. The actual code
 is 'example_stat.rb' in the 'examples' directory. Modify it as you see fit.
 
-## Known Bugs
+## Known Issues
 
-None that I'm aware of. Please report bugs on the project page at:
+Currently this may not work if you're running a 32-bit system with 64-bit offsets:
+
+  https://github.com/djberg96/sys-filesystem/issues/71
+
+Please report any other issues on the project home page at:
 
   https://github.com/djberg96/sys-filesystem
 
 ## Future Plans
 
-* Add better 64-bit support for Linux and BSD.
-* Other suggestions welcome.
+* Suggestions welcome.
 
 ## Acknowledgements
 

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -16,7 +16,7 @@ module Sys
   # return objects of other types. Do not instantiate.
   class Filesystem
     # The version of the sys-filesystem library
-    VERSION = '1.5.2'
+    VERSION = '1.5.3'
 
     # Stat objects are returned by the Sys::Filesystem.stat method. Here
     # we're adding universal methods.

--- a/spec/sys_filesystem_shared.rb
+++ b/spec/sys_filesystem_shared.rb
@@ -4,7 +4,7 @@ require 'sys-filesystem'
 
 RSpec.shared_examples Sys::Filesystem do
   example 'version number is set to the expected value' do
-    expect(Sys::Filesystem::VERSION).to eq('1.5.2')
+    expect(Sys::Filesystem::VERSION).to eq('1.5.3')
     expect(Sys::Filesystem::VERSION).to be_frozen
   end
 

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-filesystem'
-  spec.version    = '1.5.2'
+  spec.version    = '1.5.3'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.cert_chain = Dir['certs/*']
    
   spec.add_dependency('ffi', '~> 1.1')
-  spec.add_dependency('mkmf-lite', '~> 0.7') unless Gem.win_platform?
+  spec.add_development_dependency('mkmf-lite', '~> 0.7') unless Gem.win_platform?
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec', '~> 3.9')
   spec.add_development_dependency('rubocop')


### PR DESCRIPTION
Explains the changes for 1.5.3, and moves mkmf-lite back to a dev dependency.