### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |spec|
     'source_code_uri'       => 'https://github.com/djberg96/sys-filesystem',
     'wiki_uri'              => 'https://github.com/djberg96/sys-filesystem/wiki',
     'rubygems_mfa_required' => 'true',
-    'github_repo'           => 'https://github.com/djberg96/sys-filesystem' 
+    'github_repo'           => 'https://github.com/djberg96/sys-filesystem',
+    'funding_uri'           => 'https://github.com/sponsors/djberg96'
   }
 
   spec.description = <<-EOF


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.