### PR TITLE
Update linux64? method

### DIFF
--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -16,7 +16,7 @@ module Sys
             ENV_JAVA['sun.arch.data.model'].to_i == 64
         else
           RbConfig::CONFIG['host_os'] =~ /linux/i &&
-            RbConfig::SIZEOF['void*'] == 8
+            [nil].pack('P').size == 8
         end
       end
 

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -16,7 +16,7 @@ module Sys
             ENV_JAVA['sun.arch.data.model'].to_i == 64
         else
           RbConfig::CONFIG['host_os'] =~ /linux/i &&
-            (RbConfig::CONFIG['arch'] =~ /64/ || RbConfig::CONFIG['DEFS'] =~ /64/)
+            RbConfig::SIZEOF['void*'] == 8
         end
       end
 

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -524,4 +524,139 @@ RSpec.describe Sys::Filesystem, :unix do
       expect(Sys::Filesystem::Functions.attached_functions[:statvfs64]).to be_nil
     end
   end
+
+  describe 'linux64? method' do
+    let(:functions_class) { Sys::Filesystem::Functions }
+
+    # Helper method to test linux64? with mocked config
+    def test_linux64_with_config(host_os, pointer_size, ruby_platform = nil, java_arch = nil)
+      # Mock RbConfig::CONFIG
+      allow(RbConfig::CONFIG).to receive(:[]).and_call_original
+      allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return(host_os)
+
+      if ruby_platform == 'java'
+        # Mock RUBY_PLATFORM for JRuby tests
+        stub_const('RUBY_PLATFORM', 'java')
+
+        # Mock ENV_JAVA for JRuby
+        env_java_mock = double('ENV_JAVA')
+        allow(env_java_mock).to receive(:[]).with('sun.arch.data.model').and_return(java_arch.to_s)
+        stub_const('ENV_JAVA', env_java_mock)
+      else
+        # Mock the pack method for regular Ruby
+        packed_data = 'x' * pointer_size
+        allow_any_instance_of(Array).to receive(:pack).with('P').and_return(packed_data)
+      end
+
+      functions_class.send(:linux64?)
+    end
+
+    context 'with different Linux distributions on 64-bit architectures' do
+      let(:linux_distros) do
+        {
+          'x86_64-linux-gnu' => 'Ubuntu/Debian x86_64',
+          'x86_64-pc-linux-gnu' => 'Generic x86_64 Linux',
+          'aarch64-linux-gnu' => 'ARM64 (Raspberry Pi 4, AWS Graviton)',
+          's390x-linux-gnu' => 'IBM Z mainframe',
+          'powerpc64le-linux-gnu' => 'POWER8/9 little-endian',
+          'powerpc64-linux-gnu' => 'POWER8/9 big-endian',
+          'mips64el-linux-gnuabi64' => 'MIPS64 little-endian',
+          'alpha-linux-gnu' => 'DEC Alpha',
+          'sparc64-linux-gnu' => 'SPARC64',
+          'riscv64-linux-gnu' => 'RISC-V 64-bit'
+        }
+      end
+
+      it 'returns true for 64-bit Linux systems' do
+        linux_distros.each do |host_os, description|
+          result = test_linux64_with_config(host_os, 8)
+          expect(result).to be_truthy, "Expected linux64? to return true for #{host_os} (#{description})"
+        end
+      end
+    end
+
+    context 'with different Linux distributions on 32-bit architectures' do
+      let(:linux_32bit_distros) do
+        {
+          'i386-linux-gnu' => '32-bit x86',
+          'i486-linux-gnu' => '32-bit x86',
+          'i586-linux-gnu' => '32-bit x86',
+          'i686-linux-gnu' => '32-bit x86',
+          'arm-linux-gnueabihf' => 'ARM 32-bit hard-float',
+          'armv7l-linux-gnueabihf' => 'ARMv7 32-bit',
+          'mips-linux-gnu' => 'MIPS 32-bit',
+          'mipsel-linux-gnu' => 'MIPS 32-bit little-endian',
+          'powerpc-linux-gnu' => 'PowerPC 32-bit',
+          's390-linux-gnu' => 'IBM S/390 32-bit'
+        }
+      end
+
+      it 'returns false for 32-bit Linux systems' do
+        linux_32bit_distros.each do |host_os, description|
+          result = test_linux64_with_config(host_os, 4)
+          expect(result).to be_falsey, "Expected linux64? to return false for #{host_os} (#{description})"
+        end
+      end
+    end
+
+    context 'with non-Linux operating systems' do
+      let(:non_linux_os) do
+        {
+          'darwin21.6.0' => 'macOS',
+          'freebsd13.1' => 'FreeBSD',
+          'openbsd7.2' => 'OpenBSD',
+          'netbsd9.3' => 'NetBSD',
+          'dragonfly6.4' => 'DragonFlyBSD',
+          'solaris2.11' => 'Solaris',
+          'aix7.2.0.0' => 'AIX',
+          'mingw32' => 'Windows MSYS2',
+          'cygwin' => 'Cygwin'
+        }
+      end
+
+      it 'returns false for non-Linux systems regardless of architecture' do
+        non_linux_os.each do |host_os, description|
+          # Test both 32-bit and 64-bit scenarios
+          [4, 8].each do |pointer_size|
+            result = test_linux64_with_config(host_os, pointer_size)
+            expect(result).to be_falsey,
+              "Expected linux64? to return false for #{host_os} (#{description}) with #{pointer_size * 8}-bit pointers"
+          end
+        end
+      end
+    end
+
+    context 'with JRuby on different platforms' do
+      it 'returns true for 64-bit Linux on JRuby' do
+        result = test_linux64_with_config('x86_64-linux-gnu', nil, 'java', 64)
+        expect(result).to be_truthy
+      end
+
+      it 'returns false for 32-bit Linux on JRuby' do
+        result = test_linux64_with_config('i386-linux-gnu', nil, 'java', 32)
+        expect(result).to be_falsey
+      end
+
+      it 'returns false for non-Linux systems on JRuby' do
+        result = test_linux64_with_config('darwin21.6.0', nil, 'java', 64)
+        expect(result).to be_falsey
+      end
+    end
+
+    context 'edge cases' do
+      it 'handles case-insensitive Linux detection' do
+        ['LINUX-gnu', 'Linux-gnu', 'linux-GNU'].each do |host_os|
+          result = test_linux64_with_config(host_os, 8)
+          expect(result).to be_truthy, "Expected linux64? to handle case-insensitive matching for #{host_os}"
+        end
+      end
+
+      it 'handles partial Linux matches in host_os string' do
+        ['some-linux-variant', 'embedded-linux-system', 'custom-linux-build'].each do |host_os|
+          result = test_linux64_with_config(host_os, 8)
+          expect(result).to be_truthy, "Expected linux64? to match partial Linux strings for #{host_os}"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Apparently not all 64-bit Linux distros have 64 in the name or DEFS. Use a pointer size check.