### PR TITLE
BSD updates and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 *.gem
+.vscode

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 1.6.0 - ???
+* Big refactor for BSD mainly, adds statfs, and zfs related properties if
+  you're using ZFS. Also works for Linux on ZFS.
+* Split out constants into platform specific files for easier maintenance.
+* Add MNT_NFS4ACLS constant for FreeBSD.
+* Update mount and umount methods, preferring nmount where supported.
+
 ## 1.5.5 - 6-Dec-2025
 * Replaced string concatenation operators with addition assignment operators
   since the current code generates a frozen string warning with Ruby 3.4 and

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -21,6 +21,20 @@ module Sys
     # Stat objects are returned by the Sys::Filesystem.stat method. Here
     # we're adding universal methods.
     class Stat
+      ZFS_PROPERTIES = {
+        zfs_atime: 'atime',
+        zfs_casesensitivity: 'casesensitivity',
+        zfs_compression: 'compression',
+        zfs_compressratio: 'compressratio',
+        zfs_devices: 'devices',
+        zfs_exec: 'exec',
+        zfs_quota: 'quota',
+        zfs_readonly: 'readonly',
+        zfs_recordsize: 'recordsize',
+        zfs_reservation: 'reservation',
+        zfs_setuid: 'setuid'
+      }.freeze
+
       # Returns true if the filesystem is case sensitive for the current path.
       # Typically this will be any path on MS Windows or Macs using HFS.
       #
@@ -49,15 +63,32 @@ module Sys
         !case_insensitive?
       end
 
+      # Returns a native ZFS property value for this path's dataset.
+      # Returns nil if the path is not on ZFS or libzfs is unavailable.
+      def zfs_property(property)
+        return nil unless base_type == 'zfs'
+        return nil unless Sys::Filesystem.respond_to?(:zfs_property, true)
+
+        dataset = zfs_dataset
+        return nil unless dataset
+
+        Sys::Filesystem.send(:zfs_property, dataset, property.to_s)
+      rescue SystemCallError
+        nil
+      end
+
+      ZFS_PROPERTIES.each do |method_name, property|
+        define_method(method_name) do
+          zfs_property(property)
+        end
+      end
+
       private
 
       def zfs_case_insensitive?
         return nil unless base_type == 'zfs'
 
-        dataset = zfs_dataset
-        return nil unless dataset
-
-        value = Sys::Filesystem.send(:zfs_property, dataset, 'casesensitivity')
+        value = zfs_property('casesensitivity')
         return nil unless value
 
         case value.strip

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -31,10 +31,15 @@ module Sys
       def case_insensitive?
         if path =~ /\w+/
           File.identical?(path, path.swapcase)
-        elsif RbConfig::CONFIG['host_os'] =~ /darwin|mac|windows|mswin|mingw/i
-          true # Assumes HFS/APFS on Mac
         else
-          false
+          zfs_case = zfs_case_insensitive?
+          return zfs_case unless zfs_case.nil?
+
+          if RbConfig::CONFIG['host_os'] =~ /darwin|mac|windows|mswin|mingw/i
+            true # Assumes HFS/APFS on Mac
+          else
+            false
+          end
         end
       end
 
@@ -42,6 +47,38 @@ module Sys
       #
       def case_sensitive?
         !case_insensitive?
+      end
+
+      private
+
+      def zfs_case_insensitive?
+        return nil unless base_type == 'zfs'
+
+        dataset = zfs_dataset
+        return nil unless dataset
+
+        value = Sys::Filesystem.send(:zfs_property, dataset, 'casesensitivity')
+        return nil unless value
+
+        case value.strip
+          when 'insensitive'
+            true
+          when 'sensitive'
+            false
+          else
+            nil
+        end
+      rescue SystemCallError
+        nil
+      end
+
+      def zfs_dataset
+        mount_point = Sys::Filesystem.mount_point(path)
+        mount = Sys::Filesystem.mounts.find{ |mnt| mnt.mount_point == mount_point }
+
+        mount&.name
+      rescue SystemCallError
+        nil
       end
     end
   end

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -16,7 +16,7 @@ module Sys
   # return objects of other types. Do not instantiate.
   class Filesystem
     # The version of the sys-filesystem library
-    VERSION = '1.5.5'
+    VERSION = '1.6.0'
 
     # Stat objects are returned by the Sys::Filesystem.stat method. Here
     # we're adding universal methods.

--- a/lib/sys/filesystem.rb
+++ b/lib/sys/filesystem.rb
@@ -73,6 +73,8 @@ module Sys
       end
 
       def zfs_dataset
+        return mount_source if respond_to?(:mount_source) && mount_source
+
         mount_point = Sys::Filesystem.mount_point(path)
         mount = Sys::Filesystem.mounts.find{ |mnt| mnt.mount_point == mount_point }
 

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -13,32 +13,6 @@ module Sys
 
     private_class_method :new
 
-    # Readable versions of constant names
-    OPT_NAMES = {
-      MNT_RDONLY => 'read-only',
-      MNT_SYNCHRONOUS => 'synchronous',
-      MNT_NOEXEC => 'noexec',
-      MNT_NOSUID => 'nosuid',
-      MNT_NODEV => 'nodev',
-      MNT_UNION => 'union',
-      MNT_ASYNC => 'asynchronous',
-      MNT_CPROTECT => 'content-protection',
-      MNT_EXPORTED => 'exported',
-      MNT_QUARANTINE => 'quarantined',
-      MNT_LOCAL => 'local',
-      MNT_QUOTA => 'quotas',
-      MNT_ROOTFS => 'rootfs',
-      MNT_DONTBROWSE => 'nobrowse',
-      MNT_IGNORE_OWNERSHIP => 'noowners',
-      MNT_AUTOMOUNTED => 'automounted',
-      MNT_JOURNALED => 'journaled',
-      MNT_NOUSERXATTR => 'nouserxattr',
-      MNT_DEFWRITE => 'defwrite',
-      MNT_NOATIME => 'noatime'
-    }.freeze
-
-    private_constant :OPT_NAMES
-
     # File used to read mount informtion from.
     if File.exist?('/etc/mtab')
       MOUNT_FILE = '/etc/mtab'.freeze
@@ -318,7 +292,7 @@ module Sys
           string = ''
           flags = mnt[:f_flags] & MNT_VISFLAGMASK
 
-          OPT_NAMES.each do |key, val|
+          Constants::MOUNT_OPTION_NAMES.each do |key, val|
             if flags & key > 0
               if string.empty?
                 string += val

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -12,6 +12,7 @@ module Sys
     extend Sys::Filesystem::Functions
 
     private_class_method :new
+    private_class_method(*Sys::Filesystem::Functions.attached_functions.keys)
 
     # File used to read mount informtion from.
     if File.exist?('/etc/mtab')

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -79,6 +79,18 @@ module Sys
       # The filesystem type, e.g. UFS.
       attr_accessor :base_type
 
+      # The name of the mounted resource.
+      attr_accessor :mount_source
+
+      # The mount point/directory.
+      attr_accessor :mount_point
+
+      # The type of filesystem mount, e.g. ufs, zfs, nfs, etc.
+      attr_accessor :mount_type
+
+      # A list of comma separated options for the mount, e.g. nosuid, etc.
+      attr_accessor :mount_options
+
       # The filesystem type
       attr_accessor :filesystem_type
 
@@ -118,6 +130,10 @@ module Sys
         @flags            = nil
         @name_max         = nil
         @base_type        = nil
+        @mount_source     = nil
+        @mount_point      = nil
+        @mount_type       = nil
+        @mount_options    = nil
         @filesystem_type  = nil
         @owner            = nil
         @sync_reads       = nil
@@ -258,6 +274,10 @@ module Sys
         obj.flags = native_fs[:f_flags] if native_fs.members.include?(:f_flags)
         obj.name_max = native_fs[:f_namemax] if native_fs.members.include?(:f_namemax)
         obj.base_type = native_fs[:f_fstypename].to_s if native_fs.members.include?(:f_fstypename)
+        obj.mount_type = native_fs[:f_fstypename].to_s if native_fs.members.include?(:f_fstypename)
+        obj.mount_source = native_fs[:f_mntfromname].to_s if native_fs.members.include?(:f_mntfromname)
+        obj.mount_point = native_fs[:f_mntonname].to_s if native_fs.members.include?(:f_mntonname)
+        obj.mount_options = decode_mount_options(native_fs[:f_flags]) if native_fs.members.include?(:f_flags)
         obj.filesystem_type = native_fs[:f_type] if native_fs.members.include?(:f_type)
         obj.owner = native_fs[:f_owner] if native_fs.members.include?(:f_owner)
         obj.sync_reads = native_fs[:f_syncreads] if native_fs.members.include?(:f_syncreads)
@@ -280,8 +300,31 @@ module Sys
         obj.async_writes = fs[:f_asyncwrites]
       end
 
+      enrich_mount_metadata(obj) unless obj.mount_point
+
       obj.freeze
     end
+
+    def self.enrich_mount_metadata(stat)
+      mount = mount_for_path(stat.path)
+      return unless mount
+
+      stat.mount_source = mount.name
+      stat.mount_point = mount.mount_point
+      stat.mount_type = mount.mount_type
+      stat.mount_options = mount.options
+    end
+
+    private_class_method :enrich_mount_metadata
+
+    def self.mount_for_path(path)
+      mount_path = mount_point(path)
+      mounts.find{ |mount| mount.mount_point == mount_path }
+    rescue SystemCallError
+      nil
+    end
+
+    private_class_method :mount_for_path
 
     def self.normalize_filesystem_id(fsid)
       return fsid unless fsid.respond_to?(:to_a)
@@ -322,6 +365,26 @@ module Sys
 
     private_class_method :zfs_property
 
+    def self.decode_mount_options(flags)
+      string = ''
+      visible_flags = flags & MNT_VISFLAGMASK
+
+      Constants::MOUNT_OPTION_NAMES.each do |key, val|
+        if visible_flags & key > 0
+          if string.empty?
+            string += val
+          else
+            string += ", #{val}"
+          end
+        end
+        visible_flags &= ~key
+      end
+
+      string
+    end
+
+    private_class_method :decode_mount_options
+
     # In block form, yields a Sys::Filesystem::Mount object for each mounted
     # filesytem on the host. Otherwise it returns an array of Mount objects.
     #
@@ -356,21 +419,7 @@ module Sys
           obj.mount_point = mnt[:f_mntonname].to_s
           obj.mount_type = mnt[:f_fstypename].to_s
 
-          string = ''
-          flags = mnt[:f_flags] & MNT_VISFLAGMASK
-
-          Constants::MOUNT_OPTION_NAMES.each do |key, val|
-            if flags & key > 0
-              if string.empty?
-                string += val
-              else
-                string += ", #{val}"
-              end
-            end
-            flags &= ~key
-          end
-
-          obj.options = string
+          obj.options = decode_mount_options(mnt[:f_flags])
 
           if block_given?
             yield obj.freeze

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -338,10 +338,16 @@ module Sys
     def self.zfs_property(dataset, property)
       return nil unless respond_to?(:libzfs_init, true)
 
+      cache = zfs_property_cache if property == 'casesensitivity'
+      key = [dataset, property]
+
+      return cache[key] if cache&.key?(key)
+
       handle = libzfs_init
       return nil if handle.null?
 
       zfs_handle = nil
+      value = nil
 
       begin
         prop = zfs_name_to_prop(property)
@@ -353,17 +359,26 @@ module Sys
         buffer = FFI::MemoryPointer.new(:char, 8192)
 
         if zfs_prop_get(zfs_handle, prop, buffer, buffer.size, nil, nil, 0, 0).zero?
-          buffer.read_string
+          value = buffer.read_string
         end
       ensure
         zfs_close(zfs_handle) if zfs_handle && !zfs_handle.null?
         libzfs_fini(handle)
       end
+
+      cache[key] = value if cache && value
+      value
     rescue FFI::NotFoundError, SystemCallError
       nil
     end
 
     private_class_method :zfs_property
+
+    def self.zfs_property_cache
+      @zfs_property_cache ||= {}
+    end
+
+    private_class_method :zfs_property_cache
 
     def self.decode_mount_options(flags)
       string = ''

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -118,6 +118,12 @@ module Sys
         @flags            = nil
         @name_max         = nil
         @base_type        = nil
+        @filesystem_type  = nil
+        @owner            = nil
+        @sync_reads       = nil
+        @sync_writes      = nil
+        @async_reads      = nil
+        @async_writes     = nil
       end
 
       # Returns the total space on the partition.
@@ -242,6 +248,28 @@ module Sys
         obj.base_type = fs[:f_basetype].to_s
       end
 
+      if respond_to?(:statfs, true)
+        native_fs = Statfs.new
+
+        if statfs(path, native_fs) < 0
+          raise Error, "statfs() function failed: #{strerror(FFI.errno)}"
+        end
+
+        obj.flags = native_fs[:f_flags] if native_fs.members.include?(:f_flags)
+        obj.name_max = native_fs[:f_namemax] if native_fs.members.include?(:f_namemax)
+        obj.base_type = native_fs[:f_fstypename].to_s if native_fs.members.include?(:f_fstypename)
+        obj.filesystem_type = native_fs[:f_type] if native_fs.members.include?(:f_type)
+        obj.owner = native_fs[:f_owner] if native_fs.members.include?(:f_owner)
+        obj.sync_reads = native_fs[:f_syncreads] if native_fs.members.include?(:f_syncreads)
+        obj.async_reads = native_fs[:f_asyncreads] if native_fs.members.include?(:f_asyncreads)
+        obj.sync_writes = native_fs[:f_syncwrites] if native_fs.members.include?(:f_syncwrites)
+        obj.async_writes = native_fs[:f_asyncwrites] if native_fs.members.include?(:f_asyncwrites)
+
+        if native_fs.members.include?(:f_fsid)
+          obj.filesystem_id = normalize_filesystem_id(native_fs[:f_fsid])
+        end
+      end
+
       # DragonFlyBSD has additional struct members
       if RbConfig::CONFIG['host_os'] =~ /dragonfly/i
         obj.owner = fs[:f_owner]
@@ -254,6 +282,15 @@ module Sys
 
       obj.freeze
     end
+
+    def self.normalize_filesystem_id(fsid)
+      return fsid unless fsid.respond_to?(:to_a)
+
+      high, low = fsid.to_a
+      ((high & 0xffffffff) << 32) | (low & 0xffffffff)
+    end
+
+    private_class_method :normalize_filesystem_id
 
     # In block form, yields a Sys::Filesystem::Mount object for each mounted
     # filesytem on the host. Otherwise it returns an array of Mount objects.

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -292,6 +292,36 @@ module Sys
 
     private_class_method :normalize_filesystem_id
 
+    def self.zfs_property(dataset, property)
+      return nil unless respond_to?(:libzfs_init, true)
+
+      handle = libzfs_init
+      return nil if handle.null?
+
+      zfs_handle = nil
+
+      begin
+        prop = zfs_name_to_prop(property)
+        return nil if prop < 0
+
+        zfs_handle = zfs_open(handle, dataset, 1) # ZFS_TYPE_FILESYSTEM
+        return nil if zfs_handle.null?
+
+        buffer = FFI::MemoryPointer.new(:char, 8192)
+
+        if zfs_prop_get(zfs_handle, prop, buffer, buffer.size, nil, nil, 0, 0).zero?
+          buffer.read_string
+        end
+      ensure
+        zfs_close(zfs_handle) if zfs_handle && !zfs_handle.null?
+        libzfs_fini(handle)
+      end
+    rescue FFI::NotFoundError, SystemCallError
+      nil
+    end
+
+    private_class_method :zfs_property
+
     # In block form, yields a Sys::Filesystem::Mount object for each mounted
     # filesytem on the host. Otherwise it returns an array of Mount objects.
     #

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -265,6 +265,10 @@ module Sys
         obj.base_type = fs[:f_basetype].to_s
       end
 
+      # Keep statvfs as the portable source for capacity/inode data, but use
+      # native statfs where available for mount metadata that POSIX statvfs
+      # does not expose. On FreeBSD this includes the filesystem type name,
+      # mount source/target, native MNT_* flags, owner, and I/O counters.
       if respond_to?(:statfs, true)
         native_fs = Statfs.new
 

--- a/lib/sys/unix/sys/filesystem.rb
+++ b/lib/sys/unix/sys/filesystem.rb
@@ -469,12 +469,67 @@ module Sys
     #   Sys::Filesystem.mount('/dev/loop0', '/home/you/tmp', 'ext4', Sys::Filesystem::MNT_RDONLY)
     #
     def self.mount(source, target, fstype = 'ext2', flags = 0, data = nil)
-      if mount_c(source, target, fstype, flags, data) != 0
+      result =
+        if respond_to?(:nmount_c, true)
+          iov = nmount_iovec(source, target, fstype, data)
+          nmount_c(iov[:pointer], iov[:count], flags)
+        elsif RbConfig::CONFIG['host_os'] =~ /linux/i
+          mount_c(source, target, fstype, flags, data)
+        else
+          mount_c(fstype, target, flags, mount_data_pointer(source, data))
+        end
+
+      if result != 0
         raise Error, "mount() function failed: #{strerror(FFI.errno)}"
       end
 
       self
     end
+
+    def self.nmount_iovec(source, target, fstype, data)
+      options = {
+        'fstype' => fstype,
+        'fspath' => target
+      }
+
+      options['from'] = source if source
+
+      if data
+        unless data.respond_to?(:to_hash)
+          raise ArgumentError, 'data must be a Hash of nmount option names and values'
+        end
+
+        data.to_hash.each{ |key, value| options[key.to_s] = value }
+      end
+
+      strings = options.flat_map do |key, value|
+        [FFI::MemoryPointer.from_string(key), FFI::MemoryPointer.from_string(value.to_s)]
+      end
+
+      pointer = FFI::MemoryPointer.new(Iovec, strings.length)
+
+      strings.each_with_index do |string, index|
+        iov = Iovec.new(pointer + (index * Iovec.size))
+        iov[:iov_base] = string
+        iov[:iov_len] = string.size
+      end
+
+      { pointer: pointer, count: strings.length, strings: strings }
+    end
+
+    private_class_method :nmount_iovec
+
+    def self.mount_data_pointer(source, data)
+      if data
+        FFI::MemoryPointer.from_string(data.to_s)
+      elsif source
+        FFI::MemoryPointer.from_string(source.to_s)
+      else
+        FFI::Pointer::NULL
+      end
+    end
+
+    private_class_method :mount_data_pointer
 
     # Removes the attachment of the (topmost) filesystem mounted on target.
     # You may also specify bitwise OR'd +flags+ to control the precise behavior.
@@ -487,8 +542,8 @@ module Sys
     #
     # * UMOUNT_NOFOLLOW - Don't dereference the target if it's a symbolic link.
     #
-    # Note that BSD platforms may support different flags. Please see the man
-    # pages for details.
+    # On BSD platforms, MNT_FORCE may be used to force an unmount. FreeBSD also
+    # supports MNT_BYFSID for unmounting by filesystem id.
     #
     # Typically this method requires admin privileges.
     #

--- a/lib/sys/unix/sys/filesystem/constants.rb
+++ b/lib/sys/unix/sys/filesystem/constants.rb
@@ -1,74 +1,16 @@
 # frozen_string_literal: true
 
-module Sys
-  class Filesystem
-    module Constants
-      MNT_RDONLY      = 0x00000001 # read only filesystem
-      MNT_SYNCHRONOUS = 0x00000002 # file system written synchronously
-      MNT_NOEXEC      = 0x00000004 # can't exec from filesystem
-      MNT_NOSUID      = 0x00000008 # don't honor setuid bits on fs
-      MNT_NODEV       = 0x00000010 # don't interpret special files
-      MNT_UNION       = 0x00000020 # union with underlying filesystem
-      MNT_ASYNC       = 0x00000040 # file system written asynchronously
-      MNT_CPROTECT    = 0x00000080 # file system supports content protection
-      MNT_EXPORTED    = 0x00000100 # file system is exported
-      MNT_QUARANTINE  = 0x00000400 # file system is quarantined
-      MNT_LOCAL       = 0x00001000 # filesystem is stored locally
-      MNT_QUOTA       = 0x00002000 # quotas are enabled on filesystem
-      MNT_ROOTFS      = 0x00004000 # identifies the root filesystem
-      MNT_DOVOLFS     = 0x00008000 # FS supports volfs (deprecated)
-      MNT_DONTBROWSE  = 0x00100000 # FS is not appropriate path to user data
-      MNT_IGNORE_OWNERSHIP = 0x00200000 # VFS will ignore ownership info on FS objects
-      MNT_AUTOMOUNTED = 0x00400000 # filesystem was mounted by automounter
-      MNT_JOURNALED   = 0x00800000 # filesystem is journaled
-      MNT_NOUSERXATTR = 0x01000000 # Don't allow user extended attributes
-      MNT_DEFWRITE    = 0x02000000 # filesystem should defer writes
-      MNT_MULTILABEL  = 0x04000000 # MAC support for individual labels
-      MNT_NOATIME     = 0x10000000 # disable update of file access time
-      MNT_NOCLUSTERR  = 0x40000000 # disable cluster read
-      MNT_NOCLUSTERW  = 0x80000000 # disable cluster write
+require 'rbconfig'
 
-      MNT_VISFLAGMASK = (
-        MNT_RDONLY | MNT_SYNCHRONOUS | MNT_NOEXEC |
-        MNT_NOSUID | MNT_NODEV | MNT_UNION |
-        MNT_ASYNC  | MNT_EXPORTED | MNT_QUARANTINE |
-        MNT_LOCAL  | MNT_QUOTA |
-        MNT_ROOTFS | MNT_DOVOLFS | MNT_DONTBROWSE |
-        MNT_IGNORE_OWNERSHIP | MNT_AUTOMOUNTED | MNT_JOURNALED |
-        MNT_NOUSERXATTR | MNT_DEFWRITE | MNT_MULTILABEL |
-        MNT_NOATIME | MNT_CPROTECT
-      )
-
-      MS_RDONLY = 1
-      MS_NOSUID = 2
-      MS_NODEV = 4
-      MS_NOEXEC = 8
-      MS_SYNCHRONOUS = 16
-      MS_REMOUNT = 32
-      MS_MANDLOCK = 64
-      MS_DIRSYNC = 128
-      MS_NOATIME = 1024
-      MS_NODIRATIME = 2048
-      MS_BIND = 4096
-      MS_MOVE = 8192
-      MS_REC = 16384
-      MS_SILENT = 32768
-      MS_POSIXACL = 1 << 16
-      MS_UNBINDABLE = 1 << 17
-      MS_PRIVATE = 1 << 18
-      MS_SLAVE = 1 << 19
-      MS_SHARED = 1 << 20
-      MS_RELATIME = 1 << 21
-      MS_KERNMOUNT = 1 << 22
-      MS_I_VERSION = 1 << 23
-      MS_STRICTATIME = 1 << 24
-      MS_ACTIVE = 1 << 30
-      MS_NOUSER = 1 << 31
-
-      MNT_FORCE = 1
-      MNT_DETACH = 2
-      MNT_EXPIRE = 4
-      UMOUNT_NOFOLLOW = 8
-    end
-  end
+case RbConfig::CONFIG['host_os']
+  when /linux/i
+    require_relative 'constants/linux'
+  when /freebsd/i
+    require_relative 'constants/freebsd'
+  when /darwin|osx|mach/i
+    require_relative 'constants/darwin'
+  when /dragonfly/i
+    require_relative 'constants/dragonfly'
+  else
+    require_relative 'constants/generic'
 end

--- a/lib/sys/unix/sys/filesystem/constants/bsd.rb
+++ b/lib/sys/unix/sys/filesystem/constants/bsd.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Sys
+  class Filesystem
+    module Constants
+      MNT_RDONLY      = 0x00000001 # read only filesystem
+      MNT_SYNCHRONOUS = 0x00000002 # file system written synchronously
+      MNT_NOEXEC      = 0x00000004 # can't exec from filesystem
+      MNT_NOSUID      = 0x00000008 # don't honor setuid bits on fs
+      MNT_UNION       = 0x00000020 # union with underlying filesystem
+      MNT_ASYNC       = 0x00000040 # file system written asynchronously
+      MNT_EXPORTED    = 0x00000100 # filesystem is exported
+      MNT_LOCAL       = 0x00001000 # filesystem is stored locally
+      MNT_QUOTA       = 0x00002000 # quotas are enabled on filesystem
+      MNT_ROOTFS      = 0x00004000 # identifies the root filesystem
+      MNT_NOATIME     = 0x10000000 # disable update of file access time
+
+      MNT_VISFLAGMASK = (
+        MNT_RDONLY | MNT_SYNCHRONOUS | MNT_NOEXEC |
+        MNT_NOSUID | MNT_UNION | MNT_ASYNC |
+        MNT_EXPORTED | MNT_LOCAL | MNT_QUOTA |
+        MNT_ROOTFS | MNT_NOATIME
+      )
+
+      MNT_FORCE = 1
+
+      MOUNT_OPTION_NAMES = {
+        MNT_RDONLY => 'read-only',
+        MNT_SYNCHRONOUS => 'synchronous',
+        MNT_NOEXEC => 'noexec',
+        MNT_NOSUID => 'nosuid',
+        MNT_UNION => 'union',
+        MNT_ASYNC => 'asynchronous',
+        MNT_EXPORTED => 'exported',
+        MNT_LOCAL => 'local',
+        MNT_QUOTA => 'quotas',
+        MNT_ROOTFS => 'rootfs',
+        MNT_NOATIME => 'noatime'
+      }.freeze
+    end
+  end
+end

--- a/lib/sys/unix/sys/filesystem/constants/darwin.rb
+++ b/lib/sys/unix/sys/filesystem/constants/darwin.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Sys
+  class Filesystem
+    module Constants
+      MNT_RDONLY      = 0x00000001 # read only filesystem
+      MNT_SYNCHRONOUS = 0x00000002 # file system written synchronously
+      MNT_NOEXEC      = 0x00000004 # can't exec from filesystem
+      MNT_NOSUID      = 0x00000008 # don't honor setuid bits on fs
+      MNT_NODEV       = 0x00000010 # don't interpret special files
+      MNT_UNION       = 0x00000020 # union with underlying filesystem
+      MNT_ASYNC       = 0x00000040 # file system written asynchronously
+      MNT_CPROTECT    = 0x00000080 # file system supports content protection
+      MNT_EXPORTED    = 0x00000100 # file system is exported
+      MNT_QUARANTINE  = 0x00000400 # file system is quarantined
+      MNT_LOCAL       = 0x00001000 # filesystem is stored locally
+      MNT_QUOTA       = 0x00002000 # quotas are enabled on filesystem
+      MNT_ROOTFS      = 0x00004000 # identifies the root filesystem
+      MNT_DOVOLFS     = 0x00008000 # FS supports volfs (deprecated)
+      MNT_DONTBROWSE  = 0x00100000 # FS is not appropriate path to user data
+      MNT_IGNORE_OWNERSHIP = 0x00200000 # VFS will ignore ownership info on FS objects
+      MNT_AUTOMOUNTED = 0x00400000 # filesystem was mounted by automounter
+      MNT_JOURNALED   = 0x00800000 # filesystem is journaled
+      MNT_NOUSERXATTR = 0x01000000 # Don't allow user extended attributes
+      MNT_DEFWRITE    = 0x02000000 # filesystem should defer writes
+      MNT_MULTILABEL  = 0x04000000 # MAC support for individual labels
+      MNT_NOATIME     = 0x10000000 # disable update of file access time
+      MNT_NOCLUSTERR  = 0x40000000 # disable cluster read
+      MNT_NOCLUSTERW  = 0x80000000 # disable cluster write
+
+      MNT_VISFLAGMASK = (
+        MNT_RDONLY | MNT_SYNCHRONOUS | MNT_NOEXEC |
+        MNT_NOSUID | MNT_NODEV | MNT_UNION |
+        MNT_ASYNC  | MNT_EXPORTED | MNT_QUARANTINE |
+        MNT_LOCAL  | MNT_QUOTA |
+        MNT_ROOTFS | MNT_DOVOLFS | MNT_DONTBROWSE |
+        MNT_IGNORE_OWNERSHIP | MNT_AUTOMOUNTED | MNT_JOURNALED |
+        MNT_NOUSERXATTR | MNT_DEFWRITE | MNT_MULTILABEL |
+        MNT_NOATIME | MNT_CPROTECT
+      )
+
+      MNT_FORCE = 1
+
+      MOUNT_OPTION_NAMES = {
+        MNT_RDONLY => 'read-only',
+        MNT_SYNCHRONOUS => 'synchronous',
+        MNT_NOEXEC => 'noexec',
+        MNT_NOSUID => 'nosuid',
+        MNT_NODEV => 'nodev',
+        MNT_UNION => 'union',
+        MNT_ASYNC => 'asynchronous',
+        MNT_CPROTECT => 'content-protection',
+        MNT_EXPORTED => 'exported',
+        MNT_QUARANTINE => 'quarantined',
+        MNT_LOCAL => 'local',
+        MNT_QUOTA => 'quotas',
+        MNT_ROOTFS => 'rootfs',
+        MNT_DONTBROWSE => 'nobrowse',
+        MNT_IGNORE_OWNERSHIP => 'noowners',
+        MNT_AUTOMOUNTED => 'automounted',
+        MNT_JOURNALED => 'journaled',
+        MNT_NOUSERXATTR => 'nouserxattr',
+        MNT_DEFWRITE => 'defwrite',
+        MNT_NOATIME => 'noatime'
+      }.freeze
+    end
+  end
+end

--- a/lib/sys/unix/sys/filesystem/constants/dragonfly.rb
+++ b/lib/sys/unix/sys/filesystem/constants/dragonfly.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'generic'

--- a/lib/sys/unix/sys/filesystem/constants/dragonfly.rb
+++ b/lib/sys/unix/sys/filesystem/constants/dragonfly.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require_relative 'generic'
+require_relative 'bsd'

--- a/lib/sys/unix/sys/filesystem/constants/freebsd.rb
+++ b/lib/sys/unix/sys/filesystem/constants/freebsd.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Sys
+  class Filesystem
+    module Constants
+      MNT_RDONLY      = 0x0000000000000001 # read only filesystem
+      MNT_SYNCHRONOUS = 0x0000000000000002 # file system written synchronously
+      MNT_NOEXEC      = 0x0000000000000004 # can't exec from filesystem
+      MNT_NOSUID      = 0x0000000000000008 # don't honor setuid bits on fs
+      MNT_NFS4ACLS    = 0x0000000000000010 # enable NFS version 4 ACLs
+      MNT_UNION       = 0x0000000000000020 # union with underlying filesystem
+      MNT_ASYNC       = 0x0000000000000040 # file system written asynchronously
+      MNT_EXRDONLY    = 0x0000000000000080 # exported read only
+      MNT_EXPORTED    = 0x0000000000000100 # filesystem is exported
+      MNT_DEFEXPORTED = 0x0000000000000200 # exported to the world
+      MNT_EXPORTANON  = 0x0000000000000400 # anon uid mapping for all
+      MNT_EXKERB      = 0x0000000000000800 # exported with Kerberos
+      MNT_LOCAL       = 0x0000000000001000 # filesystem is stored locally
+      MNT_QUOTA       = 0x0000000000002000 # quotas are enabled on filesystem
+      MNT_ROOTFS      = 0x0000000000004000 # identifies the root filesystem
+      MNT_USER        = 0x0000000000008000 # mounted by a user
+      MNT_SUIDDIR     = 0x0000000000100000 # special SUID dir handling
+      MNT_SOFTDEP     = 0x0000000000200000 # using soft updates
+      MNT_NOSYMFOLLOW = 0x0000000000400000 # do not follow symlinks
+      MNT_IGNORE      = 0x0000000000800000 # do not show entry in df
+      MNT_GJOURNAL    = 0x0000000002000000 # GEOM journal support enabled
+      MNT_MULTILABEL  = 0x0000000004000000 # MAC support for objects
+      MNT_ACLS        = 0x0000000008000000 # ACL support enabled
+      MNT_NOATIME     = 0x0000000010000000 # disable update of file access time
+      MNT_EXPUBLIC    = 0x0000000020000000 # public export (WebNFS)
+      MNT_NOCLUSTERR  = 0x0000000040000000 # disable cluster read
+      MNT_NOCLUSTERW  = 0x0000000080000000 # disable cluster write
+      MNT_SUJ         = 0x0000000100000000 # using journaled soft updates
+      MNT_AUTOMOUNTED = 0x0000000200000000 # filesystem was mounted by automounter
+      MNT_VERIFIED    = 0x0000000400000000 # filesystem is verified
+      MNT_UNTRUSTED   = 0x0000000800000000 # filesystem metadata is untrusted
+      MNT_NAMEDATTR   = 0x0000020000000000 # named attributes enabled
+
+      MNT_VISFLAGMASK = (
+        MNT_RDONLY | MNT_SYNCHRONOUS | MNT_NOEXEC |
+        MNT_NOSUID | MNT_NFS4ACLS | MNT_UNION |
+        MNT_ASYNC | MNT_EXRDONLY | MNT_EXPORTED |
+        MNT_DEFEXPORTED | MNT_EXPORTANON | MNT_EXKERB |
+        MNT_LOCAL | MNT_USER | MNT_QUOTA |
+        MNT_ROOTFS | MNT_NOATIME | MNT_NOCLUSTERR |
+        MNT_NOCLUSTERW | MNT_SUIDDIR | MNT_SOFTDEP |
+        MNT_IGNORE | MNT_EXPUBLIC | MNT_NOSYMFOLLOW |
+        MNT_GJOURNAL | MNT_MULTILABEL | MNT_ACLS |
+        MNT_NFS4ACLS | MNT_AUTOMOUNTED | MNT_VERIFIED |
+        MNT_UNTRUSTED | MNT_NAMEDATTR
+      )
+
+      MNT_UPDATE    = 0x0000000000010000
+      MNT_DELEXPORT = 0x0000000000020000
+      MNT_RELOAD    = 0x0000000000040000
+      MNT_FORCE     = 0x0000000000080000
+      MNT_SNAPSHOT  = 0x0000000001000000
+      MNT_NONBUSY   = 0x0000000004000000
+      MNT_BYFSID    = 0x0000000008000000
+      MNT_NOCOVER   = 0x0000001000000000
+      MNT_EMPTYDIR  = 0x0000002000000000
+      MNT_RECURSE   = 0x0000100000000000
+      MNT_DEFERRED  = 0x0000200000000000
+
+      MOUNT_OPTION_NAMES = {
+        MNT_RDONLY => 'read-only',
+        MNT_SYNCHRONOUS => 'synchronous',
+        MNT_NOEXEC => 'noexec',
+        MNT_NOSUID => 'nosuid',
+        MNT_NFS4ACLS => 'nfsv4acls',
+        MNT_UNION => 'union',
+        MNT_ASYNC => 'asynchronous',
+        MNT_EXRDONLY => 'exported-read-only',
+        MNT_EXPORTED => 'exported',
+        MNT_DEFEXPORTED => 'defexported',
+        MNT_EXPORTANON => 'exportanon',
+        MNT_EXKERB => 'exkerb',
+        MNT_LOCAL => 'local',
+        MNT_USER => 'user',
+        MNT_QUOTA => 'quotas',
+        MNT_ROOTFS => 'rootfs',
+        MNT_NOATIME => 'noatime',
+        MNT_NOCLUSTERR => 'noclusterr',
+        MNT_NOCLUSTERW => 'noclusterw',
+        MNT_SUIDDIR => 'suiddir',
+        MNT_SOFTDEP => 'soft-updates',
+        MNT_IGNORE => 'ignore',
+        MNT_EXPUBLIC => 'public',
+        MNT_NOSYMFOLLOW => 'nosymfollow',
+        MNT_GJOURNAL => 'gjournal',
+        MNT_MULTILABEL => 'multilabel',
+        MNT_ACLS => 'acls',
+        MNT_AUTOMOUNTED => 'automounted',
+        MNT_VERIFIED => 'verified',
+        MNT_UNTRUSTED => 'untrusted',
+        MNT_NAMEDATTR => 'namedattr'
+      }.freeze
+    end
+  end
+end

--- a/lib/sys/unix/sys/filesystem/constants/generic.rb
+++ b/lib/sys/unix/sys/filesystem/constants/generic.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'darwin'

--- a/lib/sys/unix/sys/filesystem/constants/generic.rb
+++ b/lib/sys/unix/sys/filesystem/constants/generic.rb
@@ -1,3 +1,19 @@
 # frozen_string_literal: true
 
-require_relative 'darwin'
+module Sys
+  class Filesystem
+    module Constants
+      MNT_RDONLY = 0x00000001
+      MNT_NOSUID = 0x00000002
+
+      MNT_VISFLAGMASK = MNT_RDONLY | MNT_NOSUID
+
+      MNT_FORCE = 1
+
+      MOUNT_OPTION_NAMES = {
+        MNT_RDONLY => 'read-only',
+        MNT_NOSUID => 'nosuid'
+      }.freeze
+    end
+  end
+end

--- a/lib/sys/unix/sys/filesystem/constants/linux.rb
+++ b/lib/sys/unix/sys/filesystem/constants/linux.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Sys
+  class Filesystem
+    module Constants
+      MS_RDONLY = 1
+      MS_NOSUID = 2
+      MS_NODEV = 4
+      MS_NOEXEC = 8
+      MS_SYNCHRONOUS = 16
+      MS_REMOUNT = 32
+      MS_MANDLOCK = 64
+      MS_DIRSYNC = 128
+      MS_NOATIME = 1024
+      MS_NODIRATIME = 2048
+      MS_BIND = 4096
+      MS_MOVE = 8192
+      MS_REC = 16_384
+      MS_SILENT = 32_768
+      MS_POSIXACL = 1 << 16
+      MS_UNBINDABLE = 1 << 17
+      MS_PRIVATE = 1 << 18
+      MS_SLAVE = 1 << 19
+      MS_SHARED = 1 << 20
+      MS_RELATIME = 1 << 21
+      MS_KERNMOUNT = 1 << 22
+      MS_I_VERSION = 1 << 23
+      MS_STRICTATIME = 1 << 24
+      MS_ACTIVE = 1 << 30
+      MS_NOUSER = 1 << 31
+
+      MNT_RDONLY = MS_RDONLY
+      MNT_NOSUID = MS_NOSUID
+      MNT_NODEV = MS_NODEV
+      MNT_NOEXEC = MS_NOEXEC
+
+      MNT_FORCE = 1
+      MNT_DETACH = 2
+      MNT_EXPIRE = 4
+      UMOUNT_NOFOLLOW = 8
+    end
+  end
+end

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -32,6 +32,10 @@ module Sys
         attach_function(:statvfs, %i[string pointer], :int)
       end
 
+      if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd|dragonfly/i
+        attach_function(:statfs, %i[string pointer], :int)
+      end
+
       attach_function(:strerror, [:int], :string)
       attach_function(:mount_c, :mount, %i[string string string ulong string], :int)
 
@@ -42,6 +46,7 @@ module Sys
       end
 
       private_class_method :statvfs, :strerror, :mount_c, :umount_c
+      private_class_method :statfs if method_defined?(:statfs)
 
       begin
         attach_function(:getmntent, [:pointer], :pointer)

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -37,7 +37,16 @@ module Sys
       end
 
       attach_function(:strerror, [:int], :string)
-      attach_function(:mount_c, :mount, %i[string string string ulong string], :int)
+
+      if RbConfig::CONFIG['host_os'] =~ /linux/i
+        attach_function(:mount_c, :mount, %i[string string string ulong string], :int)
+      else
+        attach_function(:mount_c, :mount, %i[string string int pointer], :int)
+      end
+
+      if RbConfig::CONFIG['host_os'] =~ /freebsd/i
+        attach_function(:nmount_c, :nmount, %i[pointer uint int], :int)
+      end
 
       begin
         ffi_lib FFI::Library::LIBC, 'zfs'
@@ -64,6 +73,7 @@ module Sys
 
       private_class_method :statvfs, :strerror, :mount_c, :umount_c
       private_class_method :statfs if method_defined?(:statfs)
+      private_class_method :nmount_c if method_defined?(:nmount_c)
       if method_defined?(:libzfs_init)
         private_class_method(
           :libzfs_init,

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -39,6 +39,23 @@ module Sys
       attach_function(:strerror, [:int], :string)
       attach_function(:mount_c, :mount, %i[string string string ulong string], :int)
 
+      begin
+        ffi_lib FFI::Library::LIBC, 'zfs'
+
+        attach_function(:libzfs_init, [], :pointer)
+        attach_function(:libzfs_fini, [:pointer], :void)
+        attach_function(:zfs_open, %i[pointer string int], :pointer)
+        attach_function(:zfs_close, [:pointer], :void)
+        attach_function(:zfs_name_to_prop, [:string], :int)
+        attach_function(
+          :zfs_prop_get,
+          %i[pointer int pointer size_t pointer pointer size_t int],
+          :int
+        )
+      rescue FFI::NotFoundError
+        # libzfs is optional. ZFS-specific helpers fall back when unavailable.
+      end
+
       if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd|dragonfly/i
         attach_function(:umount_c, :unmount, %i[string int], :int)
       else
@@ -47,6 +64,16 @@ module Sys
 
       private_class_method :statvfs, :strerror, :mount_c, :umount_c
       private_class_method :statfs if method_defined?(:statfs)
+      if method_defined?(:libzfs_init)
+        private_class_method(
+          :libzfs_init,
+          :libzfs_fini,
+          :zfs_open,
+          :zfs_close,
+          :zfs_name_to_prop,
+          :zfs_prop_get
+        )
+      end
 
       begin
         attach_function(:getmntent, [:pointer], :pointer)

--- a/lib/sys/unix/sys/filesystem/functions.rb
+++ b/lib/sys/unix/sys/filesystem/functions.rb
@@ -20,7 +20,12 @@ module Sys
         end
       end
 
+      def self.zfs_supported?
+        !!(RbConfig::CONFIG['host_os'] =~ /freebsd|linux/i)
+      end
+
       private_class_method :linux64?
+      private_class_method :zfs_supported?
 
       if linux64?
         begin
@@ -48,21 +53,23 @@ module Sys
         attach_function(:nmount_c, :nmount, %i[pointer uint int], :int)
       end
 
-      begin
-        ffi_lib FFI::Library::LIBC, 'zfs'
+      if zfs_supported?
+        begin
+          ffi_lib FFI::Library::LIBC, 'zfs'
 
-        attach_function(:libzfs_init, [], :pointer)
-        attach_function(:libzfs_fini, [:pointer], :void)
-        attach_function(:zfs_open, %i[pointer string int], :pointer)
-        attach_function(:zfs_close, [:pointer], :void)
-        attach_function(:zfs_name_to_prop, [:string], :int)
-        attach_function(
-          :zfs_prop_get,
-          %i[pointer int pointer size_t pointer pointer size_t int],
-          :int
-        )
-      rescue FFI::NotFoundError
-        # libzfs is optional. ZFS-specific helpers fall back when unavailable.
+          attach_function(:libzfs_init, [], :pointer)
+          attach_function(:libzfs_fini, [:pointer], :void)
+          attach_function(:zfs_open, %i[pointer string int], :pointer)
+          attach_function(:zfs_close, [:pointer], :void)
+          attach_function(:zfs_name_to_prop, [:string], :int)
+          attach_function(
+            :zfs_prop_get,
+            %i[pointer int pointer size_t pointer pointer size_t int],
+            :int
+          )
+        rescue FFI::NotFoundError, LoadError
+          # libzfs is optional. ZFS-specific helpers fall back when unavailable.
+        end
       end
 
       if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach|bsd|dragonfly/i

--- a/lib/sys/unix/sys/filesystem/structs.rb
+++ b/lib/sys/unix/sys/filesystem/structs.rb
@@ -256,6 +256,14 @@ module Sys
           :mnt_passno, :int
         )
       end
+
+      # The Iovec struct is used by FreeBSD's nmount(2).
+      class Iovec < FFI::Struct
+        layout(
+          :iov_base, :pointer,
+          :iov_len, :size_t
+        )
+      end
     end
   end
 end

--- a/lib/sys/windows/sys/filesystem/constants.rb
+++ b/lib/sys/windows/sys/filesystem/constants.rb
@@ -1,22 +1,3 @@
-module Sys
-  class Filesystem
-    module Constants
-      MAXPATH = 260
+# frozen_string_literal: true
 
-      CASE_SENSITIVE_SEARCH      = 0x00000001
-      CASE_PRESERVED_NAMES       = 0x00000002
-      UNICODE_ON_DISK            = 0x00000004
-      PERSISTENT_ACLS            = 0x00000008
-      FILE_COMPRESSION           = 0x00000010
-      VOLUME_QUOTAS              = 0x00000020
-      SUPPORTS_SPARSE_FILES      = 0x00000040
-      SUPPORTS_REPARSE_POINTS    = 0x00000080
-      SUPPORTS_REMOTE_STORAGE    = 0x00000100
-      VOLUME_IS_COMPRESSED       = 0x00008000
-      SUPPORTS_OBJECT_IDS        = 0x00010000
-      SUPPORTS_ENCRYPTION        = 0x00020000
-      NAMED_STREAMS              = 0x00040000
-      READ_ONLY_VOLUME           = 0x00080000
-    end
-  end
-end
+require_relative 'constants/windows'

--- a/lib/sys/windows/sys/filesystem/constants/windows.rb
+++ b/lib/sys/windows/sys/filesystem/constants/windows.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Sys
+  class Filesystem
+    module Constants
+      MAXPATH = 260
+
+      CASE_SENSITIVE_SEARCH      = 0x00000001
+      CASE_PRESERVED_NAMES       = 0x00000002
+      UNICODE_ON_DISK            = 0x00000004
+      PERSISTENT_ACLS            = 0x00000008
+      FILE_COMPRESSION           = 0x00000010
+      VOLUME_QUOTAS              = 0x00000020
+      SUPPORTS_SPARSE_FILES      = 0x00000040
+      SUPPORTS_REPARSE_POINTS    = 0x00000080
+      SUPPORTS_REMOTE_STORAGE    = 0x00000100
+      VOLUME_IS_COMPRESSED       = 0x00008000
+      SUPPORTS_OBJECT_IDS        = 0x00010000
+      SUPPORTS_ENCRYPTION        = 0x00020000
+      NAMED_STREAMS              = 0x00040000
+      READ_ONLY_VOLUME           = 0x00080000
+    end
+  end
+end

--- a/spec/sys_filesystem_shared.rb
+++ b/spec/sys_filesystem_shared.rb
@@ -4,7 +4,7 @@ require 'sys-filesystem'
 
 RSpec.shared_examples Sys::Filesystem do
   example 'version number is set to the expected value' do
-    expect(Sys::Filesystem::VERSION).to eq('1.5.5')
+    expect(Sys::Filesystem::VERSION).to eq('1.6.0')
     expect(Sys::Filesystem::VERSION).to be_frozen
   end
 

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -58,6 +58,54 @@ RSpec.describe Sys::Filesystem, :unix do
     @size  = 58720256
   end
 
+  context 'platform constants' do
+    example 'freebsd mount constants match sys/mount.h' do
+      skip 'FreeBSD constant test skipped except on FreeBSD' unless RbConfig::CONFIG['host_os'] =~ /freebsd/i
+
+      expect(described_class::MNT_RDONLY).to eq(0x0000000000000001)
+      expect(described_class::MNT_NFS4ACLS).to eq(0x0000000000000010)
+      expect(described_class.const_defined?(:MNT_NODEV)).to be(false)
+      expect(described_class::MNT_LOCAL).to eq(0x0000000000001000)
+      expect(described_class::MNT_ROOTFS).to eq(0x0000000000004000)
+      expect(described_class::MNT_NOATIME).to eq(0x0000000010000000)
+      expect(described_class::MNT_FORCE).to eq(0x0000000000080000)
+      expect(described_class::MNT_BYFSID).to eq(0x0000000008000000)
+    end
+
+    example 'freebsd mount option names decode nfsv4acls distinctly from nodev' do
+      skip 'FreeBSD option-name test skipped except on FreeBSD' unless RbConfig::CONFIG['host_os'] =~ /freebsd/i
+
+      expect(described_class.send(:decode_mount_options, described_class::MNT_NFS4ACLS)).to eq('nfsv4acls')
+      expect(described_class::Constants::MOUNT_OPTION_NAMES.value?('nodev')).to be(false)
+    end
+
+    example 'freebsd root mount options agree with stat flags' do
+      skip 'FreeBSD root option test skipped except on FreeBSD' unless RbConfig::CONFIG['host_os'] =~ /freebsd/i
+
+      expect(@stat.mount_options).to eq(described_class.send(:decode_mount_options, @stat.flags))
+    end
+
+    example 'linux mount constants expose linux flags' do
+      skip 'Linux constant test skipped except on Linux' unless linux
+
+      expect(described_class::MS_RDONLY).to eq(1)
+      expect(described_class::MS_NODEV).to eq(4)
+      expect(described_class::MNT_NODEV).to eq(described_class::MS_NODEV)
+      expect(described_class::MNT_FORCE).to eq(1)
+      expect(described_class::MNT_DETACH).to eq(2)
+      expect(described_class::UMOUNT_NOFOLLOW).to eq(8)
+    end
+
+    example 'darwin mount constants expose darwin flags' do
+      skip 'Darwin constant test skipped except on Darwin' unless darwin
+
+      expect(described_class::MNT_NODEV).to eq(0x00000010)
+      expect(described_class::MNT_CPROTECT).to eq(0x00000080)
+      expect(described_class::MNT_QUARANTINE).to eq(0x00000400)
+      expect(described_class::MNT_FORCE).to eq(1)
+    end
+  end
+
   example 'stat path works as expected' do
     expect(@stat).to respond_to(:path)
     expect(@stat.path).to eq(root)

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -102,6 +102,38 @@ RSpec.describe Sys::Filesystem, :unix do
     expect(@stat.name_max).to be_a(Numeric)
   end
 
+  context 'bsd statfs enrichments' do
+    before do
+      skip 'statfs enrichment tests skipped except on BSD' unless bsd
+    end
+
+    example 'base_type is populated from statfs' do
+      expect(@stat.base_type).to be_a(String)
+      expect(@stat.base_type).not_to be_empty
+    end
+
+    example 'base_type matches the mount type' do
+      root_mount = described_class.mounts.find{ |mount| mount.mount_point == root }
+
+      expect(@stat.base_type).to eq(root_mount.mount_type)
+    end
+
+    example 'filesystem_type is populated from statfs' do
+      expect(@stat.filesystem_type).to be_a(Numeric)
+    end
+
+    example 'owner is populated from statfs' do
+      expect(@stat.owner).to be_a(Numeric)
+    end
+
+    example 'read and write counters are populated from statfs' do
+      expect(@stat.sync_reads).to be_a(Numeric)
+      expect(@stat.async_reads).to be_a(Numeric)
+      expect(@stat.sync_writes).to be_a(Numeric)
+      expect(@stat.async_writes).to be_a(Numeric)
+    end
+  end
+
   context 'dragonfly', :dragonfly do
     example 'owner works as expected' do
       expect(@stat).to respond_to(:owner)

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -713,8 +713,10 @@ RSpec.describe Sys::Filesystem, :unix do
     let(:dummy) { Class.new { extend Mkmf::Lite } }
 
     example 'ffi functions are private' do
-      expect(described_class.methods.include?('statvfs')).to be false
-      expect(described_class.methods.include?('strerror')).to be false
+      Sys::Filesystem::Functions.attached_functions.each_key do |function_name|
+        expect(described_class.methods).not_to include(function_name)
+        expect(described_class.private_methods).to include(function_name)
+      end
     end
 
     example 'statfs struct is expected size' do

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -164,6 +164,13 @@ RSpec.describe Sys::Filesystem, :unix do
       expect(@stat.mount_options).to eq(root_mount.options)
     end
 
+    example 'zfs dataset uses stat mount metadata when available' do
+      skip 'zfs dataset test skipped except on ZFS' unless @stat.base_type == 'zfs'
+
+      expect(described_class).not_to receive(:mounts)
+      expect(@stat.send(:zfs_dataset)).to eq(@stat.mount_source)
+    end
+
     example 'filesystem_type is populated from statfs' do
       expect(@stat.filesystem_type).to be_a(Numeric)
     end

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -187,6 +187,39 @@ RSpec.describe Sys::Filesystem, :unix do
     end
   end
 
+  context 'zfs properties' do
+    before do
+      skip 'zfs property tests skipped except on ZFS' unless @stat.base_type == 'zfs'
+    end
+
+    example 'generic zfs_property returns property values' do
+      expect(@stat.zfs_property('casesensitivity')).to be_a(String)
+      expect(@stat.zfs_property(:compression)).to be_a(String)
+    end
+
+    example 'convenience methods match generic zfs_property' do
+      {
+        zfs_atime: 'atime',
+        zfs_casesensitivity: 'casesensitivity',
+        zfs_compression: 'compression',
+        zfs_compressratio: 'compressratio',
+        zfs_devices: 'devices',
+        zfs_exec: 'exec',
+        zfs_quota: 'quota',
+        zfs_readonly: 'readonly',
+        zfs_recordsize: 'recordsize',
+        zfs_reservation: 'reservation',
+        zfs_setuid: 'setuid'
+      }.each do |method_name, property|
+        expect(@stat.public_send(method_name)).to eq(@stat.zfs_property(property))
+      end
+    end
+
+    example 'unknown zfs properties return nil' do
+      expect(@stat.zfs_property('definitely_not_a_zfs_property')).to be_nil
+    end
+  end
+
   context 'dragonfly', :dragonfly do
     example 'owner works as expected' do
       expect(@stat).to respond_to(:owner)

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -104,6 +104,38 @@ RSpec.describe Sys::Filesystem, :unix do
       expect(described_class::MNT_QUARANTINE).to eq(0x00000400)
       expect(described_class::MNT_FORCE).to eq(1)
     end
+
+    example 'generic constants avoid darwin-specific flags' do
+      command = [
+        RbConfig.ruby,
+        '-Ilib',
+        '-e',
+        'require "sys/unix/sys/filesystem/constants/generic"; ' \
+        'c = Sys::Filesystem::Constants; ' \
+        'abort unless c::MNT_RDONLY == 1; ' \
+        'abort unless c::MOUNT_OPTION_NAMES[c::MNT_NOSUID] == "nosuid"; ' \
+        'abort if c.const_defined?(:MNT_CPROTECT); ' \
+        'abort if c.const_defined?(:MNT_QUARANTINE)'
+      ]
+
+      expect(system(*command)).to be(true)
+    end
+
+    example 'dragonfly constants use the shared bsd set' do
+      command = [
+        RbConfig.ruby,
+        '-Ilib',
+        '-e',
+        'require "sys/unix/sys/filesystem/constants/dragonfly"; ' \
+        'c = Sys::Filesystem::Constants; ' \
+        'abort unless c::MNT_RDONLY == 1; ' \
+        'abort unless c::MNT_LOCAL == 0x1000; ' \
+        'abort unless c::MOUNT_OPTION_NAMES[c::MNT_NOATIME] == "noatime"; ' \
+        'abort if c.const_defined?(:MNT_CPROTECT)'
+      ]
+
+      expect(system(*command)).to be(true)
+    end
   end
 
   example 'stat path works as expected' do

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -155,6 +155,15 @@ RSpec.describe Sys::Filesystem, :unix do
       expect(@stat.base_type).to eq(root_mount.mount_type)
     end
 
+    example 'mount metadata matches the mount table' do
+      root_mount = described_class.mounts.find{ |mount| mount.mount_point == root }
+
+      expect(@stat.mount_source).to eq(root_mount.name)
+      expect(@stat.mount_point).to eq(root_mount.mount_point)
+      expect(@stat.mount_type).to eq(root_mount.mount_type)
+      expect(@stat.mount_options).to eq(root_mount.options)
+    end
+
     example 'filesystem_type is populated from statfs' do
       expect(@stat.filesystem_type).to be_a(Numeric)
     end

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -557,6 +557,23 @@ RSpec.describe Sys::Filesystem, :unix do
     example 'umount singleton method is defined' do
       expect(described_class).to respond_to(:umount)
     end
+
+    example 'freebsd nmount iovec is built as expected' do
+      skip 'nmount iovec test skipped except on FreeBSD' unless RbConfig::CONFIG['host_os'] =~ /freebsd/i
+
+      iov = described_class.send(
+        :nmount_iovec,
+        '/dev/md0',
+        '/mnt/test',
+        'ufs',
+        readonly: ''
+      )
+
+      expect(iov[:count]).to eq(8)
+      expect(iov[:strings].map(&:read_string)).to eq(
+        %w[fstype ufs fspath /mnt/test from /dev/md0 readonly] + ['']
+      )
+    end
   end
 
   context 'FFI' do
@@ -585,6 +602,11 @@ RSpec.describe Sys::Filesystem, :unix do
       expect(Sys::Filesystem::Structs::Mntent.size).to eq(dummy.check_sizeof('struct mntent', 'mntent.h'))
     end
 
+    example 'iovec struct is expected size' do
+      skip 'iovec test skipped except on FreeBSD' unless RbConfig::CONFIG['host_os'] =~ /freebsd/i
+      expect(Sys::Filesystem::Structs::Iovec.size).to eq(dummy.check_sizeof('struct iovec', 'sys/uio.h'))
+    end
+
     example 'a failed statvfs call behaves as expected' do
       msg = 'statvfs() function failed: No such file or directory'
       expect{ described_class.stat('/whatever') }.to raise_error(Sys::Filesystem::Error, msg)
@@ -593,6 +615,12 @@ RSpec.describe Sys::Filesystem, :unix do
     example 'statvfs alias is used for statvfs64' do
       expect(Sys::Filesystem::Functions.attached_functions[:statvfs]).to be_a(FFI::Function)
       expect(Sys::Filesystem::Functions.attached_functions[:statvfs64]).to be_nil
+    end
+
+    example 'freebsd nmount binding is private when available' do
+      skip 'nmount test skipped except on FreeBSD' unless RbConfig::CONFIG['host_os'] =~ /freebsd/i
+      expect(described_class.methods.include?('nmount_c')).to be false
+      expect(Sys::Filesystem::Functions.attached_functions[:nmount_c]).to be_a(FFI::Function)
     end
   end
 

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -16,6 +16,43 @@ RSpec.describe Sys::Filesystem, :unix do
   let(:darwin)  { RbConfig::CONFIG['host_os'] =~ /mac|darwin/i }
   let(:root)    { '/' }
 
+  def expected_case_insensitive(stat)
+    if stat.path =~ /\w+/
+      File.identical?(stat.path, stat.path.swapcase)
+    else
+      zfs_case = zfs_case_insensitive(stat)
+      return zfs_case unless zfs_case.nil?
+
+      if darwin
+        true
+      else
+        false
+      end
+    end
+  end
+
+  def zfs_case_insensitive(stat)
+    return nil unless stat.base_type == 'zfs'
+
+    mount_point = described_class.mount_point(stat.path)
+    mount = described_class.mounts.find{ |mnt| mnt.mount_point == mount_point }
+    return nil unless mount
+
+    value = described_class.send(:zfs_property, mount.name, 'casesensitivity')
+    return nil unless value
+
+    case value.strip
+      when 'insensitive'
+        true
+      when 'sensitive'
+        false
+      else
+        nil
+    end
+  rescue SystemCallError
+    nil
+  end
+
   before do
     @stat  = described_class.stat(root)
     @size  = 58720256
@@ -203,15 +240,17 @@ RSpec.describe Sys::Filesystem, :unix do
   end
 
   example 'stat case_insensitive method works as expected' do
-    expected = darwin ? true : false
-    expect(@stat.case_insensitive?).to eq(expected)
-    expect(described_class.stat(Dir.home).case_insensitive?).to eq(expected)
+    home_stat = described_class.stat(Dir.home)
+
+    expect(@stat.case_insensitive?).to eq(expected_case_insensitive(@stat))
+    expect(home_stat.case_insensitive?).to eq(expected_case_insensitive(home_stat))
   end
 
   example 'stat case_sensitive method works as expected' do
-    expected = darwin ? false : true
-    expect(@stat.case_sensitive?).to eq(expected)
-    expect(described_class.stat(Dir.home).case_sensitive?).to eq(expected)
+    home_stat = described_class.stat(Dir.home)
+
+    expect(@stat.case_sensitive?).to eq(!expected_case_insensitive(@stat))
+    expect(home_stat.case_sensitive?).to eq(!expected_case_insensitive(home_stat))
   end
 
   example 'numeric helper methods are defined' do

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -53,6 +53,62 @@ RSpec.describe Sys::Filesystem, :unix do
     nil
   end
 
+  def write_struct_members(struct, values)
+    values.each do |member, value|
+      struct[member] = value if struct.members.include?(member)
+    end
+  end
+
+  def stub_stat_syscalls
+    statvfs_values = {
+      f_bsize: 1_048_576,
+      f_frsize: 4096,
+      f_blocks: 1_000_000,
+      f_bfree: 400_000,
+      f_bavail: 300_000,
+      f_files: 2_000_000,
+      f_ffree: 1_500_000,
+      f_favail: 1_250_000,
+      f_fsid: 1234,
+      f_flag: 1,
+      f_namemax: 255,
+      f_owner: 501,
+      f_type: 42,
+      f_syncreads: 10,
+      f_asyncreads: 20,
+      f_syncwrites: 30,
+      f_asyncwrites: 40
+    }
+
+    statfs_values = {
+      f_flags: 1,
+      f_namemax: 255,
+      f_fstypename: 'fixturefs',
+      f_mntfromname: '/dev/fixture',
+      f_mntonname: root,
+      f_type: 42,
+      f_owner: 501,
+      f_syncreads: 10,
+      f_asyncreads: 20,
+      f_syncwrites: 30,
+      f_asyncwrites: 40
+    }
+
+    allow(described_class).to receive(:statvfs) do |_path, fs|
+      write_struct_members(fs, statvfs_values)
+      0
+    end
+
+    if described_class.respond_to?(:statfs, true)
+      allow(described_class).to receive(:statfs) do |_path, fs|
+        write_struct_members(fs, statfs_values)
+        0
+      end
+    end
+
+    allow(described_class).to receive(:enrich_mount_metadata)
+  end
+
   before do
     @stat  = described_class.stat(root)
     @size  = 58720256
@@ -403,6 +459,8 @@ RSpec.describe Sys::Filesystem, :unix do
 
   context 'Filesystem.stat(Pathname)' do
     before do
+      stub_stat_syscalls
+      @stat = described_class.stat(root)
       @stat_pathname = described_class.stat(Pathname.new(root))
     end
 
@@ -465,6 +523,8 @@ RSpec.describe Sys::Filesystem, :unix do
 
   context 'Filesystem.stat(File)' do
     before do
+      stub_stat_syscalls
+      @stat = described_class.stat(root)
       @stat_file = File.open(root){ |file| described_class.stat(file) }
     end
 
@@ -527,6 +587,8 @@ RSpec.describe Sys::Filesystem, :unix do
 
   context 'Filesystem.stat(Dir)' do
     before do
+      stub_stat_syscalls
+      @stat = described_class.stat(root)
       @stat_dir = Dir.open(root){ |dir| described_class.stat(dir) }
     end
 

--- a/spec/sys_filesystem_unix_spec.rb
+++ b/spec/sys_filesystem_unix_spec.rb
@@ -751,6 +751,20 @@ RSpec.describe Sys::Filesystem, :unix do
       expect(described_class.methods.include?('nmount_c')).to be false
       expect(Sys::Filesystem::Functions.attached_functions[:nmount_c]).to be_a(FFI::Function)
     end
+
+    example 'libzfs loading is limited to zfs-capable unix platforms' do
+      functions = Sys::Filesystem::Functions
+
+      allow(RbConfig::CONFIG).to receive(:[]).and_call_original
+      allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('darwin24')
+      expect(functions.send(:zfs_supported?)).to be_falsey
+
+      allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('freebsd15.0')
+      expect(functions.send(:zfs_supported?)).to be_truthy
+
+      allow(RbConfig::CONFIG).to receive(:[]).with('host_os').and_return('linux-gnu')
+      expect(functions.send(:zfs_supported?)).to be_truthy
+    end
   end
 
   describe 'linux64? method' do

--- a/sys-filesystem.gemspec
+++ b/sys-filesystem.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'sys-filesystem'
-  spec.version    = '1.5.5'
+  spec.version    = '1.6.0'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/sys-filesystem'


### PR DESCRIPTION
# Summary

This PR improves Unix filesystem portability, with a focus on FreeBSD/ZFS correctness, while preserving the existing public API where possible.

## Changes

- Split platform constants into dedicated files under `constants/`.
- Added FreeBSD-specific mount flag values and option decoding.
- Fixed FreeBSD `nfsv4acls` decoding so it is no longer mislabeled as `nodev`.
- Added a shared BSD constants file and made generic Unix constants intentionally minimal.
- Enriched `Sys::Filesystem.stat(path)` on BSD using native `statfs(2)` data.
- Added mount metadata to `Stat`:
  - `mount_source`
  - `mount_point`
  - `mount_type`
  - `mount_options`
- Added native ZFS property lookup through `libzfs` FFI, without shelling out.
- Added ZFS convenience methods on `Stat`, including compression, record size, quota, readonly, atime, and case sensitivity.
- Updated `case_insensitive?` to use ZFS `casesensitivity` for ambiguous paths such as `/`.
- Fixed FreeBSD mount handling by using `nmount(2)` with iovec option pairs.
- Kept Linux mount handling on the existing Linux `mount(2)` signature.
- Tightened optional `libzfs` loading so macOS does not attempt to load it.
- Added platform-focused specs for constants, `statfs` enrichment, mount metadata, ZFS helpers, `nmount`, and libzfs loading behavior.

## Notes

- `Stat#flags` on BSD now reflects richer native `MNT_*` mount flags from `statfs(2)`.
- ZFS property helpers return `nil` for non-ZFS filesystems, unavailable `libzfs`, or unknown properties.
- `libzfs` loading is limited to FreeBSD/Linux and remains optional.

## Testing

Local test matrix:

- FreeBSD 15 with ZFS: passed
- FreeBSD 14 VM: passed
- Fedora Linux VM: passed
- macOS: passed
- Windows VM: passed

Command run:

```sh
bundle exec rspec
```

Latest FreeBSD result:

```text
130 examples, 0 failures, 5 pending
```
